### PR TITLE
Not to delete mig instance if 'CLIENT_IN_USE' when the permutation needs it anyway

### DIFF
--- a/pkg/mig/config/config.go
+++ b/pkg/mig/config/config.go
@@ -28,7 +28,7 @@ import (
 type Manager interface {
 	GetMigConfig(gpu int) (types.MigConfig, error)
 	SetMigConfig(gpu int, config types.MigConfig) error
-	ClearMigConfig(gpu int) error
+	ClearAndGetInstancesToCreate(gpu int, desiredConfig []types.MigProfile) ([]types.MigProfile, error)
 }
 
 type nvmlMigConfigManager struct {
@@ -144,13 +144,15 @@ func (m *nvmlMigConfigManager) SetMigConfig(gpu int, config types.MigConfig) err
 	err := iteratePermutationsUntilSuccess(config, func(mps []types.MigProfile) error {
 		clearAttempts := 0
 		maxClearAttempts := 1
+		performedClearOperationSuccessfully := false
+
 		for {
 			existingConfig, err := m.GetMigConfig(gpu)
 			if err != nil {
 				return fmt.Errorf("error getting existing MigConfig: %v", err)
 			}
 
-			if len(existingConfig.Flatten()) == 0 {
+			if performedClearOperationSuccessfully || len(existingConfig.Flatten()) == 0 {
 				break
 			}
 
@@ -158,9 +160,11 @@ func (m *nvmlMigConfigManager) SetMigConfig(gpu int, config types.MigConfig) err
 				return fmt.Errorf("exceeded maximum attempts to clear MigConfig")
 			}
 
-			err = m.ClearMigConfig(gpu)
+			mps, err = m.ClearAndGetInstancesToCreate(gpu, mps)
 			if err != nil {
 				return fmt.Errorf("error clearing MigConfig: %v", err)
+			} else {
+				performedClearOperationSuccessfully = true
 			}
 
 			clearAttempts++
@@ -201,7 +205,7 @@ func (m *nvmlMigConfigManager) SetMigConfig(gpu int, config types.MigConfig) err
 		return nil
 	})
 	if err != nil {
-		e := m.ClearMigConfig(gpu)
+		_, e := m.ClearAndGetInstancesToCreate(gpu, []types.MigProfile{})
 		if e != nil {
 			log.Errorf("Error clearing MIG config on GPU %d, erroneous devices may persist", gpu)
 		}
@@ -211,44 +215,46 @@ func (m *nvmlMigConfigManager) SetMigConfig(gpu int, config types.MigConfig) err
 	return nil
 }
 
-func (m *nvmlMigConfigManager) ClearMigConfig(gpu int) error {
+func (m *nvmlMigConfigManager) ClearAndGetInstancesToCreate(gpu int, desiredConfig []types.MigProfile) ([]types.MigProfile, error) {
 	ret := m.nvml.Init()
 	if ret.Value() != nvml.SUCCESS {
-		return fmt.Errorf("error initializing NVML: %v", ret)
+		return desiredConfig, fmt.Errorf("error initializing NVML: %v", ret)
 	}
 	defer tryNvmlShutdown(m.nvml)
 
 	device, ret := m.nvml.DeviceGetHandleByIndex(gpu)
 	if ret.Value() != nvml.SUCCESS {
-		return fmt.Errorf("error getting device handle: %v", ret)
+		return desiredConfig, fmt.Errorf("error getting device handle: %v", ret)
 	}
 
 	mode, _, ret := device.GetMigMode()
 	if ret.Value() == nvml.ERROR_NOT_SUPPORTED {
-		return fmt.Errorf("MIG not supported")
+		return desiredConfig, fmt.Errorf("MIG not supported")
 	}
 	if ret.Value() != nvml.SUCCESS {
-		return fmt.Errorf("error getting MIG mode: %v", ret)
+		return desiredConfig, fmt.Errorf("error getting MIG mode: %v", ret)
 	}
 	if mode != nvml.DEVICE_MIG_ENABLE {
-		return fmt.Errorf("MIG mode disabled")
+		return desiredConfig, fmt.Errorf("MIG mode disabled")
 	}
 
+	instancesToNotCreate := map[int]bool{}
 	for i := 0; i < nvml.GPU_INSTANCE_PROFILE_COUNT; i++ {
 		giProfileInfo, ret := device.GetGpuInstanceProfileInfo(i)
 		if ret.Value() == nvml.ERROR_NOT_SUPPORTED {
 			continue
 		}
 		if ret.Value() != nvml.SUCCESS {
-			return fmt.Errorf("error getting GPU instance profile info for '%v': %v", i, ret)
+			return desiredConfig, fmt.Errorf("error getting GPU instance profile info for '%v': %v", i, ret)
 		}
 
 		gis, ret := device.GetGpuInstances(&giProfileInfo)
 		if ret.Value() != nvml.SUCCESS {
-			return fmt.Errorf("error getting GPU instances for profile '%v': %v", i, ret)
+			return desiredConfig, fmt.Errorf("error getting GPU instances for profile '%v': %v", i, ret)
 		}
 
 		for _, gi := range gis {
+			destroyGi := true
 			for j := 0; j < nvml.COMPUTE_INSTANCE_PROFILE_COUNT; j++ {
 				for k := 0; k < nvml.COMPUTE_INSTANCE_ENGINE_PROFILE_COUNT; k++ {
 					ciProfileInfo, ret := gi.GetComputeInstanceProfileInfo(j, k)
@@ -256,31 +262,70 @@ func (m *nvmlMigConfigManager) ClearMigConfig(gpu int) error {
 						continue
 					}
 					if ret.Value() != nvml.SUCCESS {
-						return fmt.Errorf("error getting Compute instance profile info for '(%v, %v)': %v", j, k, ret)
+						return desiredConfig, fmt.Errorf("error getting Compute instance profile info for '(%v, %v)': %v", j, k, ret)
 					}
 
 					cis, ret := gi.GetComputeInstances(&ciProfileInfo)
 					if ret.Value() != nvml.SUCCESS {
-						return fmt.Errorf("error getting Compute instances for profile '(%v, %v)': %v", j, k, ret)
+						return desiredConfig, fmt.Errorf("error getting Compute instances for profile '(%v, %v)': %v", j, k, ret)
 					}
 
 					for _, ci := range cis {
 						ret := ci.Destroy()
 						if ret.Value() != nvml.SUCCESS {
-							return fmt.Errorf("error destroying Compute instance for profile '(%v, %v)': %v", j, k, ret)
+							if ret.Value() == nvml.ERROR_IN_USE && len(desiredConfig) > 0 && destroyGi {
+								gpuInfo, ret := gi.GetInfo()
+								if ret.Value() != nvml.SUCCESS {
+									return desiredConfig, fmt.Errorf("error destroying Compute instance for profile '(%v, %v)': %v", j, k, ret)
+								}
+								index := getMigProfileInConfigByPosition(desiredConfig, device, gpuInfo.ProfileId, instancesToNotCreate)
+								if index != -1 {
+									instancesToNotCreate[index] = true
+									destroyGi = false
+								}
+							} else {
+								return desiredConfig, fmt.Errorf("error destroying Compute instance for profile '(%v, %v)': %v", j, k, ret)
+							}
 						}
 					}
 				}
 			}
 
-			ret := gi.Destroy()
-			if ret.Value() != nvml.SUCCESS {
-				return fmt.Errorf("error destroying GPU instance for profile '%v': %v", i, ret)
+			if destroyGi {
+				ret := gi.Destroy()
+				if ret.Value() != nvml.SUCCESS {
+					return desiredConfig, fmt.Errorf("error destroying GPU instance for profile '%v': %v", i, ret)
+				}
 			}
 		}
 	}
 
-	return nil
+	newConfig := []types.MigProfile{}
+	for i, item := range desiredConfig {
+		if !instancesToNotCreate[i] {
+			newConfig = append(newConfig, item)
+		}
+	}
+	return newConfig, nil
+}
+
+func getMigProfileInConfigByPosition(config []types.MigProfile, device nvml.Device, profileId uint32, configNotToReCreate map[int]bool) int {
+	for index, migProfile := range config {
+		giProfileID, _, _, err := migProfile.GetProfileIDs()
+		if err != nil {
+			return -1
+		}
+
+		giProfileInfo, ret := device.GetGpuInstanceProfileInfo(giProfileID)
+		if ret.Value() != nvml.SUCCESS {
+			return -1
+		}
+
+		if giProfileInfo.Id == profileId && !configNotToReCreate[index] {
+			return index
+		}
+	}
+	return -1
 }
 
 func iteratePermutationsUntilSuccess(config types.MigConfig, f func([]types.MigProfile) error) error {

--- a/pkg/mig/config/config_test.go
+++ b/pkg/mig/config/config_test.go
@@ -112,7 +112,7 @@ func TestClearMigConfig(t *testing.T) {
 			err := manager.SetMigConfig(0, tc.config)
 			require.Nil(t, err, "Unexpected failure from SetMigConfig")
 
-			err = manager.ClearMigConfig(0)
+			err, _ = manager.ClearMigConfig(0, []types.MigProfile{})
 			require.Nil(t, err, "Unexpected failure from ClearMigConfig")
 
 			config, err := manager.GetMigConfig(0)


### PR DESCRIPTION
Not to delete mig instance if 'CLIENT_IN_USE' when the permutation needs to create it anyway

Example:
Current config:
mig-devices:
            "1g.5gb": 2
            "2g.10gb": 1
            "3g.20gb": 1
(A process runs on a single '1g.5gb')

Desired config:
mig-devices:
            "1g.5gb": 7


What would now happen is a failure because when the mig-parted try to delete all the instances of the current-config it gets 'CLIENT_IN_USE' because of the running process on the '1g.5gb'.

However, even if it delete it successfully it would then re-create if because of the desired-config

In this PR:
If you get CLIENT_IN_USE when trying to delete mig-instance - then check if you would anyway try to create it.
If true: dont delete this instance - and dont try to create it

Signed-off-by: omer-dayan <omerxdayan1@gmail.com>