### PR TITLE
Fix docker install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,12 +151,13 @@ To build from source, please follow one of the methods below.
 
 #### Use `docker` with `go install`:
 ```
-${DOCKER} run \
+docker run \
+    --rm \
     -v $(pwd):/dest \
-    golang:1.16.4 \
+    golang:1.20.1 \
     sh -c "
-    go install github.com/NVIDIA/mig-parted/cmd@latest
-    mv /go/bin/cmd /dest/nvidia-mig-parted
+    go install github.com/NVIDIA/mig-parted/cmd/nvidia-mig-parted@latest
+    mv /go/bin/nvidia-mig-parted /dest/nvidia-mig-parted
     "
 ```
 


### PR DESCRIPTION
The docker instructions as written do not work, but using the pure go example below I noticed it was just missing a path element. This seems to fix it for me.