### PR TITLE
Fix make targets which generate mig-parted packages

### DIFF
--- a/deployments/systemd/packages/Makefile
+++ b/deployments/systemd/packages/Makefile
@@ -30,7 +30,7 @@ PACKAGE_VERSION := $(VERSION:v%=%)
 
 ##### Public rules #####
 
-VALID_TARGETS = tarball ubuntu18.04 ubuntu20.04 ubi8
+VALID_TARGETS = tarball ubuntu20.04 ubi8
 
 all: $(VALID_TARGETS)
 .PHONY: all $(VALID_TARGETS)
@@ -43,20 +43,6 @@ tarball:
 		--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
 		--tag $(IMAGE):$(vVERSION)-tarball \
 		--file Dockerfile.tarball \
-		$(BUILD_DIR)
-	$(DOCKER) run \
-		-v $$(pwd)/dist/$(@):/dist \
-		$(IMAGE):$(vVERSION)-$(@)
-
-ubuntu18.04:
-	$(DOCKER) build --pull \
-		--build-arg PACKAGE_NAME=$(NAME) \
-		--build-arg PACKAGE_VERSION=$(PACKAGE_VERSION) \
-		--build-arg PACKAGE_REVISION=$(REVISION) \
-		--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
-		--build-arg BASE_IMAGE=nvcr.io/nvidia/cuda:${CUDA_VERSION}-base-ubuntu18.04 \
-		--tag $(IMAGE):$(vVERSION)-ubuntu18.04 \
-		--file Dockerfile.ubuntu \
 		$(BUILD_DIR)
 	$(DOCKER) run \
 		-v $$(pwd)/dist/$(@):/dist \

--- a/deployments/systemd/packages/Makefile
+++ b/deployments/systemd/packages/Makefile
@@ -25,6 +25,9 @@ REGISTRY ?= nvcr.io/nvidia
 IMAGE := $(REGISTRY)/$(NAME)
 endif
 
+# strip 'v' from version string
+PACKAGE_VERSION := $(VERSION:v%=%)
+
 ##### Public rules #####
 
 VALID_TARGETS = tarball ubuntu18.04 ubuntu20.04 ubi8
@@ -35,7 +38,7 @@ all: $(VALID_TARGETS)
 tarball:
 	$(DOCKER) build --pull \
 		--build-arg PACKAGE_NAME=$(NAME) \
-		--build-arg PACKAGE_VERSION=$(VERSION) \
+		--build-arg PACKAGE_VERSION=$(PACKAGE_VERSION) \
 		--build-arg PACKAGE_REVISION=$(REVISION) \
 		--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
 		--tag $(IMAGE):$(vVERSION)-tarball \
@@ -48,7 +51,7 @@ tarball:
 ubuntu18.04:
 	$(DOCKER) build --pull \
 		--build-arg PACKAGE_NAME=$(NAME) \
-		--build-arg PACKAGE_VERSION=$(VERSION) \
+		--build-arg PACKAGE_VERSION=$(PACKAGE_VERSION) \
 		--build-arg PACKAGE_REVISION=$(REVISION) \
 		--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
 		--build-arg BASE_IMAGE=nvcr.io/nvidia/cuda:${CUDA_VERSION}-base-ubuntu18.04 \
@@ -62,7 +65,7 @@ ubuntu18.04:
 ubuntu20.04:
 	$(DOCKER) build --pull \
 		--build-arg PACKAGE_NAME=$(NAME) \
-		--build-arg PACKAGE_VERSION=$(VERSION) \
+		--build-arg PACKAGE_VERSION=$(PACKAGE_VERSION) \
 		--build-arg PACKAGE_REVISION=$(REVISION) \
 		--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
 		--build-arg BASE_IMAGE=nvcr.io/nvidia/cuda:${CUDA_VERSION}-base-ubuntu20.04 \
@@ -76,7 +79,7 @@ ubuntu20.04:
 ubi8:
 	$(DOCKER) build --pull \
 		--build-arg PACKAGE_NAME=$(NAME) \
-		--build-arg PACKAGE_VERSION=$(VERSION) \
+		--build-arg PACKAGE_VERSION=$(PACKAGE_VERSION) \
 		--build-arg PACKAGE_REVISION=$(REVISION) \
 		--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
 		--build-arg BASE_IMAGE=nvcr.io/nvidia/cuda:${CUDA_VERSION}-base-ubi8 \


### PR DESCRIPTION
A previous commit, https://github.com/NVIDIA/mig-parted/commit/6d18ec1b2aa4c2efb3f26c5c7b560c1c567f14a7, added a leading 'v' to our top level VERSION variable in `versions.mk`. Since then, building the mig-parted packages fails since the `PACKAGE_VERSION` (which now has a leading 'v') does not match the version string in our changelogs: https://github.com/NVIDIA/mig-parted/blob/v0.6.0/deployments/systemd/packages/Dockerfile.ubuntu#L53. 

This PR strips the leading 'v' in the `PACKAGE_VERSION` and removes the ubuntu18.04 make targets since ubuntu18.04 tags are no longer being pushed for CUDA images starting with CUDA 12.3.2.