### PR TITLE
bump golang version in mig-manager dockerfiles

### DIFF
--- a/deployments/container/Dockerfile.ubi8
+++ b/deployments/container/Dockerfile.ubi8
@@ -21,7 +21,7 @@ RUN yum install -y \
      && \
     rm -rf /var/cache/yum/*
 
-ARG GOLANG_VERSION=1.20.5
+ARG GOLANG_VERSION=1.22.2
 RUN set -eux; \
     \
     arch="$(uname -m)"; \

--- a/deployments/container/Dockerfile.ubuntu
+++ b/deployments/container/Dockerfile.ubuntu
@@ -21,7 +21,7 @@ RUN apt-get update && \
     && \
     rm -rf /var/lib/apt/lists/*
 
-ARG GOLANG_VERSION=1.20.5
+ARG GOLANG_VERSION=1.22.2
 RUN set -eux; \
     \
     arch="$(uname -m)"; \


### PR DESCRIPTION
Since we've marked the required go toolchain version as "1.22.2" in `go.mod`, I think it would be consistent to build the mig-parted binary with the same version