### PR TITLE
Bump golang version to 1.22.4

### DIFF
--- a/deployments/systemd/install.sh
+++ b/deployments/systemd/install.sh
@@ -45,7 +45,7 @@ chmod a+rx ${PROFILED_DIR}
 
 ${DOCKER} run --rm \
 	-v ${BINARY_DIR}:/dest \
-	golang:1.22.2 \
+	golang:1.22.4 \
 	sh -c "
 	go install $MIG_PARTED_GO_GET_PATH@latest
 	mv /go/bin/nvidia-mig-parted /dest/nvidia-mig-parted

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/NVIDIA/mig-parted
 
 go 1.21
 
-toolchain go1.22.2
+toolchain go1.22.4
 
 require (
 	github.com/NVIDIA/go-nvlib v0.3.0

--- a/versions.mk
+++ b/versions.mk
@@ -17,7 +17,7 @@ VERSION ?= v0.7.0
 
 vVERSION := v$(VERSION:v%=%)
 
-GOLANG_VERSION := 1.22.2
+GOLANG_VERSION := 1.22.4
 
 BUILDIMAGE_TAG ?= devel-go$(GOLANG_VERSION)
 BUILDIMAGE ?=  ghcr.io/nvidia/k8s-test-infra:$(BUILDIMAGE_TAG)


### PR DESCRIPTION
This fixes a high CVE present in the golang 1.22.2 standard library: https://nvd.nist.gov/vuln/detail/CVE-2024-24790