### PR TITLE
Fix the H100 NVL mig profile configuration in the example file

### DIFF
--- a/deployments/systemd/config-default.yaml
+++ b/deployments/systemd/config-default.yaml
@@ -151,48 +151,36 @@ mig-configs:
       mig-devices:
         "7g.96gb": 1
 
-  # H100-94GB
-  all-1g.11gb:
+  # H100 NVL 94GB
+  all-1g.12gb.me:
     - devices: all
       mig-enabled: true
       mig-devices:
-        "1g.11gb": 7
+        "1g.12gb+me": 1
 
-  all-1g.11gb.me:
+  all-1g.24gb:
     - devices: all
       mig-enabled: true
       mig-devices:
-        "1g.11gb+me": 1
+        "1g.24gb": 4
 
-  all-1g.22bg:
+  all-3g.47gb:
     - devices: all
       mig-enabled: true
       mig-devices:
-        "1g.22gb": 4
+        "3g.47gb": 2
 
-  all-2g.22gb:
+  all-4g.47gb:
     - devices: all
       mig-enabled: true
       mig-devices:
-        "2g.22gb": 3
+        "4g.47gb": 1
 
-  all-3g.44gb:
+  all-7g.94gb:
     - devices: all
       mig-enabled: true
       mig-devices:
-        "3g.44gb": 2
-
-  all-4g.44gb:
-    - devices: all
-      mig-enabled: true
-      mig-devices:
-        "4g.44gb": 1
-
-  all-7g.88gb:
-    - devices: all
-      mig-enabled: true
-      mig-devices:
-        "7g.88gb": 1
+        "7g.94gb": 1
 
   # H100-94GB, H100-80GB, H800-80GB, A100-40GB, A100-80GB, A800-40GB, A800-80GB, A30-24GB, PG506-96GB
   all-balanced:
@@ -231,11 +219,11 @@ mig-configs:
         "2g.24gb": 1
         "3g.48gb": 1
 
-    # H100-94GB
+    # H100 NVL 94GB
     - device-filter: "0x232110DE"
       devices: all
       mig-enabled: true
       mig-devices:
-        "1g.11gb": 2
-        "2g.22gb": 1
-        "3g.44gb": 1
+        "1g.12gb": 2
+        "2g.24gb": 1
+        "3g.47gb": 1


### PR DESCRIPTION
This PR fixes some mistakes in the configuration files introduced by this commit https://github.com/NVIDIA/mig-parted/commit/bcced0656db8da29c0166a6b3c7e964e4f6ca965