### PR TITLE
Add a new nvidia-gpu-services.target to ensure proper startup order

### DIFF
--- a/deployments/systemd/README.md
+++ b/deployments/systemd/README.md
@@ -39,10 +39,17 @@ because it runs a container with `go` in it to download and build the latest
 `nvidia-mig-parted` before installing it. We plan to relax this requirement in
 the near future.
 
+**Note:** When the `nvidia-mig-manager.service` is installed, an additional target,
+`nvidia-gpu-reset.target` is also installed. This new target is used to ensure the
+`nvidia-mig-manager.service` is started after the `nvidia-fabricmanager.service` and 
+`nvidia-persistenced.service`. In addition, this target allows applications like dcgm
+and nvsm to be started only after the `nvidia-mig-manager.service` has started.
+
 The following files will be added as part of this installation:
 
 * `/usr/bin/nvidia-mig-parted`
 * `/usr/lib/systemd/system/nvidia-mig-manager.service`
+* `/usr/lib/systemd/system/nvidia-gpu-reset.target`
 * `/etc/systemd/system/nvidia-mig-manager.service.d/override.conf`
 * `/etc/profile.d/nvidia-mig-parted.sh`
 * `/etc/nvidia-mig-manager/utils.sh`

--- a/deployments/systemd/install.sh
+++ b/deployments/systemd/install.sh
@@ -19,6 +19,9 @@
 SERVICE_ROOT="nvidia-mig-manager"
 SERVICE_NAME="${SERVICE_ROOT}.service"
 
+GPU_TARGET_ROOT="nvidia-gpu-reset"
+GPU_TARGET_NAME="${GPU_TARGET_ROOT}.target"
+
 MIG_PARTED_NAME="nvidia-mig-parted"
 MIG_PARTED_GO_GET_PATH="github.com/NVIDIA/mig-parted/cmd/${MIG_PARTED_NAME}"
 
@@ -52,6 +55,7 @@ ${DOCKER} run --rm \
 	"
 
 cp ${SERVICE_NAME}       ${SYSTEMD_DIR}
+cp ${GPU_TARGET_NAME}    ${SYSTEMD_DIR}
 cp ${MIG_PARTED_NAME}.sh ${PROFILED_DIR}
 cp override.conf         ${OVERRIDE_DIR}
 cp service.sh            ${CONFIG_DIR}
@@ -62,6 +66,7 @@ cp hooks-minimal.yaml    ${CONFIG_DIR}
 cp config-default.yaml    ${CONFIG_DIR}
 
 chmod a+r ${SYSTEMD_DIR}/${SERVICE_NAME}
+chmod a+r ${SYSTEMD_DIR}/${GPU_TARGET_NAME}
 chmod a+r ${PROFILED_DIR}/${MIG_PARTED_NAME}.sh
 chmod a+r ${OVERRIDE_DIR}/override.conf
 chmod a+r ${CONFIG_DIR}/service.sh

--- a/deployments/systemd/nvidia-gpu-reset.target
+++ b/deployments/systemd/nvidia-gpu-reset.target
@@ -1,4 +1,4 @@
-# Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,15 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This new target is used to ensure the nvidia-mig-manager.service is started
+# after the nvidia-fabricmanager.service`and nvidia-persistenced.service.
+# In addition, this target allows applications like dcgm and nvsm
+# to be started only after the nvidia-mig-manager.service has started.
 [Unit]
-Description=Configure MIG on NVIDIA GPUs
-DefaultDependencies=no
-After=nvidia-persistenced.service nvidia-fabricmanager.service
-Before=nvidia-gpu-reset.target
-
-[Service]
-Type=oneshot
-ExecStart=-/bin/bash /etc/nvidia-mig-manager/service.sh
-
-[Install]
-WantedBy=nvidia-gpu-reset.target
+Description=Nvidia GPU Reset Target

--- a/deployments/systemd/uninstall.sh
+++ b/deployments/systemd/uninstall.sh
@@ -17,6 +17,9 @@
 SERVICE_ROOT="nvidia-mig-manager"
 SERVICE_NAME="${SERVICE_ROOT}.service"
 
+GPU_TARGET_ROOT="nvidia-gpu-reset"
+GPU_TARGET_NAME="${GPU_TARGET_ROOT}.target"
+
 MIG_PARTED_NAME="nvidia-mig-parted"
 MIG_PARTED_GO_GET_PATH="github.com/NVIDIA/mig-parted/cmd/${MIG_PARTED_NAME}"
 
@@ -36,4 +39,5 @@ rm -rf ${OVERRIDE_DIR}
 
 rm ${BINARY_DIR}/${MIG_PARTED_NAME}
 rm ${SYSTEMD_DIR}/${SERVICE_NAME}
+rm ${SYSTEMD_DIR}/${GPU_TARGET_NAME}
 rm ${PROFILED_DIR}/${MIG_PARTED_NAME}.sh


### PR DESCRIPTION
This PR adds a new systemd target to ensure the proper startup order for nvidia-mig-manager. The current settings cause a cyclical dependency on systemd-resolved. This results in broken name resolution after the system is rebooted. The systemd-resolved service needs to be manually restarted for name resolution to work properly.

```
2024-04-22T17:39:34.983435-07:00 ubuntu kernel: systemd[1]: sysinit.target: Found ordering cycle on systemd-resolved.service/start
2024-04-22T17:39:34.983437-07:00 ubuntu kernel: systemd[1]: sysinit.target: Found dependency on nvidia-mig-manager.service/start
2024-04-22T17:39:34.983429-07:00 ubuntu sbkeysync[8851]:      from /usr/share/secureboot/updates/dbx/dbxupdate_x64.bin
2024-04-22T17:39:34.983444-07:00 ubuntu kernel: systemd[1]: sysinit.target: Found dependency on sysinit.target/start
2024-04-22T17:39:34.983443-07:00 ubuntu sbkeysync[8851]:     7fddfe06c44dc4302da54577353c18fdbe11b41cb3e6064ec1c116ee102fe080
2024-04-22T17:39:34.983464-07:00 ubuntu kernel: systemd[1]: sysinit.target: Job systemd-resolved.service/start deleted to break ordering cycle starting with sysinit.target/start
```