### PR TITLE
Add H800 with PCI ID 232410DE

### DIFF
--- a/deployments/systemd/config-default.yaml
+++ b/deployments/systemd/config-default.yaml
@@ -44,7 +44,7 @@ mig-configs:
   # H100-80GB, H800-80GB, A100-80GB, A800-80GB, A100-40GB, A800-40GB
   all-1g.10gb:
     # H100-80GB, H800-80GB, A100-80GB, A800-80GB
-    - device-filter: ["0x233110DE", "0x233010DE", "0x232210DE", "0x20B210DE", "0x20B510DE", "0x20F310DE", "0x20F510DE"]
+    - device-filter: ["0x233110DE", "0x233010DE", "0x232210DE", "0x20B210DE", "0x20B510DE", "0x20F310DE", "0x20F510DE", "0x232410DE"]
       devices: all
       mig-enabled: true
       mig-devices:
@@ -194,7 +194,7 @@ mig-configs:
         "3g.20gb": 1
 
     # H100-80GB, H800-80GB, A100-80GB, A800-80GB
-    - device-filter: ["0x233110DE", "0x233010DE", "0x232210DE", "0x20B210DE", "0x20B510DE", "0x20F310DE", "0x20F510DE"]
+    - device-filter: ["0x233110DE", "0x233010DE", "0x232210DE", "0x20B210DE", "0x20B510DE", "0x20F310DE", "0x20F510DE", "0x232410DE"]
       devices: all
       mig-enabled: true
       mig-devices:


### PR DESCRIPTION
This PR adds the GPU PCI ID for an NVIDIA H800 GPU with GPU PCI ID 0x232410DE to the config-default.yaml file. 
