### PR TITLE
fix govet issue and pin golangci-lint version for CI checks

### DIFF
--- a/.github/workflows/golang.yaml
+++ b/.github/workflows/golang.yaml
@@ -45,7 +45,7 @@ jobs:
     - name: Lint
       uses: golangci/golangci-lint-action@v6
       with:
-        version: latest
+        version: v1.60.1
         args: -v --timeout 5m
         skip-cache: true
     - name: Check golang modules

--- a/cmd/nvidia-mig-parted/main.go
+++ b/cmd/nvidia-mig-parted/main.go
@@ -89,6 +89,6 @@ func main() {
 	// Run the CLI
 	err := c.Run(os.Args)
 	if err != nil {
-		log.Fatalf(util.Capitalize(err.Error()))
+		log.Fatal(util.Capitalize(err.Error()))
 	}
 }


### PR DESCRIPTION
This PR fixes a go vet lint issue which started to surface in the main branch on the latest golangci-lint version. Since we don't pin the version of golangci-lint in our GitHub action, there is no guarantee of CI check stability as the latest stable release of golangci-lint is always pulled at the time of running the CI. This PR solves this problem by pinning the version of golangc-lint so that the CI checks are stable and consistent