### PR TITLE
[no-relnote] Specify golangci-lint cache directory in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,7 @@ $(DOCKER_TARGETS): docker-%:
 		--rm \
 		-e GOCACHE=/tmp/.cache/go \
 		-e GOMODCACHE=/tmp/.cache/gomod \
+		-e GOLANGCI_LINT_CACHE=/tmp/.cache/golangci-lint \
 		-v $(PWD):/work \
 		-w /work \
 		--user $$(id -u):$$(id -g) \


### PR DESCRIPTION
Without this change, running `make docker-lint` results in the following error:
```
golangci-lint run ./...
2024/08/20 18:44:41 failed to initialize build cache at /.cache/golangci-lint: mkdir /.cache: permission denied
```