### PR TITLE
Add H200 with PCI ID 0x233510DE

### DIFF
--- a/deployments/systemd/config-default.yaml
+++ b/deployments/systemd/config-default.yaml
@@ -4,6 +4,11 @@ mig-configs:
     - devices: all
       mig-enabled: false
 
+  all-enabled:
+    - devices: all
+      mig-enabled: true
+      mig-devices: {}
+
   # A100-40GB, A800-40GB
   all-1g.5gb:
     - devices: all
@@ -44,7 +49,7 @@ mig-configs:
   # H100-80GB, H800-80GB, A100-80GB, A800-80GB, A100-40GB, A800-40GB
   all-1g.10gb:
     # H100-80GB, H800-80GB, A100-80GB, A800-80GB
-    - device-filter: ["0x233110DE", "0x233010DE", "0x232210DE", "0x20B210DE", "0x20B510DE", "0x20F310DE", "0x20F510DE", "0x232410DE"]
+    - device-filter: ["0x233010DE", "0x233110DE", "0x232210DE", "0x20B210DE", "0x20B510DE", "0x20F310DE", "0x20F510DE", "0x232410DE"]
       devices: all
       mig-enabled: true
       mig-devices:
@@ -126,32 +131,13 @@ mig-configs:
       mig-devices:
         "4g.24gb": 1
 
-  # PG506-96GB
+  # H100 NVL, H800 NVL, GH200
   all-1g.12gb:
     - devices: all
       mig-enabled: true
       mig-devices:
         "1g.12gb": 7
 
-  all-2g.24gb:
-    - devices: all
-      mig-enabled: true
-      mig-devices:
-        "2g.24gb": 3
-
-  all-3g.48gb:
-    - devices: all
-      mig-enabled: true
-      mig-devices:
-        "3g.48gb": 2
-
-  all-7g.96gb:
-    - devices: all
-      mig-enabled: true
-      mig-devices:
-        "7g.96gb": 1
-
-  # H100 NVL 94GB
   all-1g.12gb.me:
     - devices: all
       mig-enabled: true
@@ -164,6 +150,13 @@ mig-configs:
       mig-devices:
         "1g.24gb": 4
 
+  all-2g.24gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "2g.24gb": 3
+
+  # H100 NVL, H800 NVL
   all-3g.47gb:
     - devices: all
       mig-enabled: true
@@ -182,8 +175,54 @@ mig-configs:
       mig-devices:
         "7g.94gb": 1
 
-  # H100-94GB, H100-80GB, H800-80GB, A100-40GB, A100-80GB, A800-40GB, A800-80GB, A30-24GB, PG506-96GB
+  # H100-96GB, PG506-96GB, GH200
+  all-3g.48gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "3g.48gb": 2
+
+  all-4g.48gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "4g.48gb": 1
+
+  all-7g.96gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "7g.96gb": 1
+
+  # H200-141GB, H100-96GB, GH200, H100 NVL, H800 NVL, H100-80GB, H800-80GB, A800-40GB, A800-80GB, A100-40GB, A100-80GB, A30-24GB, PG506-96GB
   all-balanced:
+    # H200 141GB
+    - device-filter: ["0x233510DE"]
+      devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.18gb": 2
+        "2g.35gb": 1
+        "3g.71gb": 1
+
+    # H100 NVL, H800 NVL
+    - device-filter: ["0x232110DE", "0x233A10DE"]
+      devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.12gb": 2
+        "2g.24gb": 1
+        "3g.47gb": 1
+
+    # H100-80GB, H800-80GB, A100-80GB, A800-80GB
+    - device-filter: ["0x233010DE", "0x233110DE", "0x232210DE", "0x20B210DE", "0x20B510DE", "0x20F310DE", "0x20F510DE", "0x232410DE"]
+      devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.10gb": 2
+        "2g.20gb": 1
+        "3g.40gb": 1
+
     # A100-40GB, A800-40GB
     - device-filter: ["0x20B010DE", "0x20B110DE", "0x20F110DE", "0x20F610DE"]
       devices: all
@@ -193,15 +232,6 @@ mig-configs:
         "2g.10gb": 1
         "3g.20gb": 1
 
-    # H100-80GB, H800-80GB, A100-80GB, A800-80GB
-    - device-filter: ["0x233110DE", "0x233010DE", "0x232210DE", "0x20B210DE", "0x20B510DE", "0x20F310DE", "0x20F510DE", "0x232410DE"]
-      devices: all
-      mig-enabled: true
-      mig-devices:
-        "1g.10gb": 2
-        "2g.20gb": 1
-        "3g.40gb": 1
-
     # A30-24GB
     - device-filter: "0x20B710DE"
       devices: all
@@ -210,8 +240,8 @@ mig-configs:
         "1g.6gb": 2
         "2g.12gb": 1
 
-    # PG506-96GB
-    - device-filter: "0x20B610DE"
+    # H100-96GB, PG506-96GB, GH200, H20
+    - device-filter: ["0x234210DE", "0x233D10DE", "0x20B610DE", "0x232910DE"]
       devices: all
       mig-enabled: true
       mig-devices:
@@ -219,11 +249,45 @@ mig-configs:
         "2g.24gb": 1
         "3g.48gb": 1
 
-    # H100 NVL 94GB
-    - device-filter: "0x232110DE"
-      devices: all
+  # H200-141GB
+  all-1g.18gb:
+    - devices: all
       mig-enabled: true
       mig-devices:
-        "1g.12gb": 2
-        "2g.24gb": 1
-        "3g.47gb": 1
+        "1g.18gb": 7
+
+  all-1g.18gb.me:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.18gb+me": 1
+
+  all-1g.35gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.35gb": 4
+
+  all-2g.35gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "2g.35gb": 3
+
+  all-3g.71gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "3g.71gb": 2
+
+  all-4g.71gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "4g.71gb": 1
+
+  all-7g.141gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "7g.141gb": 1


### PR DESCRIPTION
This PR updates the config-default.yaml to include the GPU ID for the NVIDIA H200.
In addition, other changes were added to sync this file with the

`assets/state-mig-manager/0400_configmap.yaml`

in https://github.com/NVIDIA/gpu-operator/

These files should contain the same information but have drifted over time.

Fixes: #120