### PR TITLE
Update nvidia-gpu-reset.target setup

### DIFF
--- a/deployments/systemd/nvidia-mig-manager.service
+++ b/deployments/systemd/nvidia-mig-manager.service
@@ -23,4 +23,4 @@ Type=oneshot
 ExecStart=-/bin/bash /etc/nvidia-mig-manager/service.sh
 
 [Install]
-WantedBy=nvidia-gpu-reset.target
+WantedBy=multi-user.target nvidia-gpu-reset.target

--- a/deployments/systemd/packages/Dockerfile.tarball
+++ b/deployments/systemd/packages/Dockerfile.tarball
@@ -84,6 +84,7 @@ COPY ./deployments/systemd/hooks.sh ${DESTDIR}
 COPY ./deployments/systemd/hooks-default.yaml ${DESTDIR}
 COPY ./deployments/systemd/hooks-minimal.yaml ${DESTDIR}
 COPY ./deployments/systemd/nvidia-mig-manager.service ${DESTDIR}
+COPY ./deployments/systemd/nvidia-gpu-reset.target ${DESTDIR}
 COPY ./deployments/systemd/nvidia-mig-parted.sh ${DESTDIR}
 COPY ./deployments/systemd/override.conf ${DESTDIR}
 COPY ./deployments/systemd/service.sh ${DESTDIR}

--- a/deployments/systemd/packages/debian/Makefile
+++ b/deployments/systemd/packages/debian/Makefile
@@ -24,6 +24,7 @@ SOURCE7 = hooks.sh
 SOURCE8 = hooks-default.yaml
 SOURCE9 = hooks-minimal.yaml
 SOURCE10 = config-default.yaml
+SOURCE11 = nvidia-gpu-reset.target
 
 build:
 
@@ -45,3 +46,4 @@ install:
 	install -m 644 -t $(DESTDIR)/etc/nvidia-mig-manager $(SOURCE8)
 	install -m 644 -t $(DESTDIR)/etc/nvidia-mig-manager $(SOURCE9)
 	install -m 644 -t $(DESTDIR)/etc/nvidia-mig-manager $(SOURCE10)
+	install -m 644 -t $(DESTDIR)/lib/systemd/system $(SOURCE11)

--- a/deployments/systemd/packages/rpm/SPECS/nvidia-mig-manager.spec
+++ b/deployments/systemd/packages/rpm/SPECS/nvidia-mig-manager.spec
@@ -19,6 +19,7 @@ Source7: hooks.sh
 Source8: hooks-default.yaml
 Source9: hooks-minimal.yaml
 Source10: config-default.yaml
+Source11: nvidia-gpu-reset.target
 
 %description
 The NVIDIA MIG Partition Editor allows administrators to declaratively define a
@@ -38,7 +39,7 @@ cp %{SOURCE0} %{SOURCE1} \
    %{SOURCE4} %{SOURCE5} \
    %{SOURCE6} %{SOURCE7} \
    %{SOURCE8} %{SOURCE9} \
-   %{SOURCE10} \
+   %{SOURCE10} %{SOURCE11} \
     .
 
 %install
@@ -59,6 +60,7 @@ install -m 644 -t %{buildroot}/etc/nvidia-mig-manager %{SOURCE7}
 install -m 644 -t %{buildroot}/etc/nvidia-mig-manager %{SOURCE8}
 install -m 644 -t %{buildroot}/etc/nvidia-mig-manager %{SOURCE9}
 install -m 644 -t %{buildroot}/etc/nvidia-mig-manager %{SOURCE10}
+install -m 644 -t %{buildroot}/usr/lib/systemd/system %{SOURCE11}
 
 %files
 %license LICENSE
@@ -75,6 +77,7 @@ install -m 644 -t %{buildroot}/etc/nvidia-mig-manager %{SOURCE10}
 %dir /etc/systemd/system/nvidia-mig-manager.service.d
 %dir /etc/nvidia-mig-manager/
 %dir /var/lib/nvidia-mig-manager
+/usr/lib/systemd/system/nvidia-gpu-reset.target
 
 %post
 systemctl daemon-reload


### PR DESCRIPTION
This PR fixes an incorrect entry in the
nvidia-mig-manager.service. The "WantedBy" needs
to point to multi-user.target otherwise unless
something "Requires" or "Wants" nvidia-mig-manager it will not ever be started.

Also the original patch that added the target did not update the debian Makefile and RPM spec file. This resulted in the target not being installed.