### PR TITLE
add glibc/lib to library search paths

### DIFF
--- a/cmd/nvidia-mig-manager/find.go
+++ b/cmd/nvidia-mig-manager/find.go
@@ -33,6 +33,7 @@ func (r root) getDriverLibraryPath() (string, error) {
 		"/lib64",
 		"/lib/x86_64-linux-gnu",
 		"/lib/aarch64-linux-gnu",
+		"/glibc/lib",
 	}
 
 	libraryPath, err := r.findFile("libnvidia-ml.so.1", librarySearchPaths...)


### PR DESCRIPTION
## Issue
When running Talos Linux, the Nvidia driver libraries are located under /usr/local/glibc/lib, and the binaries under /usr/local/bin. Using the default search paths, and a `driver-root` value of `/usr/local` the validator is able to locate the binaries, but not the libraries.

## Proposed solution
Add "glibc/lib" to the library search path. This has been tested to work on a Talos cluster running 1.8.1, production drivers (550.90.07) and H100 GPUs

This PR is part of a set of PRs to better support Talos Linux for the GPU Operator.