### PR TITLE
Update rpm spec file to ensure the symlinks are kept during an upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.swp
 *.swo
+dist/
+.vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # NVIDIA MIG Manager Changelog
 
+- Fix rpm spec to maintain the config.yaml and hooks.yaml symlinks during an update
+
 ## v0.10.0
 - Add GH200 144G HBM3e with PCI ID x234810DE
 - Bump Golang version to v1.23.2

--- a/deployments/systemd/packages/rpm/SPECS/nvidia-mig-manager.spec
+++ b/deployments/systemd/packages/rpm/SPECS/nvidia-mig-manager.spec
@@ -112,9 +112,6 @@ maybe_add_hooks_symlink
 maybe_add_config_symlink
 
 %preun
-systemctl disable nvidia-mig-manager.service
-systemctl daemon-reload
-
 function maybe_remove_hooks_symlink() {
   local target=$(readlink -f /etc/nvidia-mig-manager/hooks.yaml)
   if [ "${target}" = "/etc/nvidia-mig-manager/hooks-minimal.yaml" ]; then
@@ -132,8 +129,13 @@ function maybe_remove_config_symlink() {
   fi
 }
 
-maybe_remove_hooks_symlink
-maybe_remove_config_symlink
+if [ $1 -eq 0 ]
+then
+  systemctl disable nvidia-mig-manager.service
+  systemctl daemon-reload
+  maybe_remove_hooks_symlink
+  maybe_remove_config_symlink
+fi
 
 %changelog
 # As of 0.6.0-1 we generate the release information automatically


### PR DESCRIPTION
    Update rpm spec file to ensure the symlinks are kept during an upgrade
    
    This PR updates the rpm spec file to ensure the symlinks to
    configf.yaml and hooks.yaml are maintained during a package upgrade.
    In addition, this also fixes an issue with the nvidia-mig-manager
    service is set to disabled during an upgrade.
    
    Currently when doing a dnf update or dnf reinstall, those two
    symlinks are removed. Adding a check around these functions:
    
    systemctl disable nvidia-mig-manager.service
    systemctl daemon-reload
    maybe_remove_hooks_symlink
    maybe_remove_config_symlink
    
    allows the symlinks to remain when a pacakge is reinstalled or updated
    and keeps the systemd service enabled.

 