### PR TITLE
add support for the B200 GPU

### DIFF
--- a/deployments/container/nvidia-mig-manager-example-hopper-blackwell.yaml
+++ b/deployments/container/nvidia-mig-manager-example-hopper-blackwell.yaml
@@ -120,11 +120,29 @@ data:
           mig-devices:
             "1g.18gb+me": 1
 
+      all-1g.23gb:
+        - devices: all
+          mig-enabled: true
+          mig-devices:
+            "1g.23gb": 7
+
+      all-1g.23gb.me:
+        - devices: all
+          mig-enabled: true
+          mig-devices:
+            "1g.23gb+me": 1
+
       all-1g.35gb:
         - devices: all
           mig-enabled: true
           mig-devices:
             "1g.35gb": 4
+
+      all-1g.45gb:
+        - devices: all
+          mig-enabled: true
+          mig-devices:
+            "1g.45gb": 4
 
       all-2g.35gb:
         - devices: all
@@ -132,11 +150,23 @@ data:
           mig-devices:
             "2g.35gb": 3
 
+      all-2g.45gb:
+        - devices: all
+          mig-enabled: true
+          mig-devices:
+            "2g.45gb": 3
+
       all-3g.71gb:
         - devices: all
           mig-enabled: true
           mig-devices:
             "3g.71gb": 2
+
+      all-3g.90gb:
+        - devices: all
+          mig-enabled: true
+          mig-devices:
+            "3g.90gb": 2
 
       all-4g.71gb:
         - devices: all
@@ -149,6 +179,12 @@ data:
           mig-enabled: true
           mig-devices:
             "7g.141gb": 1
+
+      all-7g.180gb:
+        - devices: all
+          mig-enabled: true
+          mig-devices:
+            "7g.180gb": 1
 
       # H100-80GB, H800-80GB
       all-1g.10gb:
@@ -224,8 +260,16 @@ data:
           mig-devices:
             "7g.94gb": 1
 
-      # H100-80GB, H100-NVL, H800-80GB, H800-NVL
+      # B200, H100-80GB, H100-NVL, H800-80GB, H800-NVL
       all-balanced:
+        # B200
+        - device-filter: ["0x290110DE"]
+          devices: all
+          mig-enabled: true
+          mig-devices:
+            "1g.23gb": 2
+            "2g.45gb": 1
+            "3g.90gb": 1
         # H200 141GB, H200 NVL
         - device-filter: ["0x233510DE", "0x233B10DE"]
           devices: all

--- a/deployments/systemd/config-default.yaml
+++ b/deployments/systemd/config-default.yaml
@@ -194,8 +194,16 @@ mig-configs:
       mig-devices:
         "7g.96gb": 1
 
-  # GH200 144G HBM3e, H200-141GB, H200 NVL, H100-96GB, GH200, H100 NVL, H800 NVL, H100-80GB, H800-80GB, A800-40GB, A800-80GB, A100-40GB, A100-80GB, A30-24GB, PG506-96GB
+  # B200, GH200 144G HBM3e, H200-141GB, H200 NVL, H100-96GB, GH200, H100 NVL, H800 NVL, H100-80GB, H800-80GB, A800-40GB, A800-80GB, A100-40GB, A100-80GB, A30-24GB, PG506-96GB
   all-balanced:
+    # B200
+    - device-filter: [ "0x290110DE" ]
+      devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.23gb": 2
+        "2g.45gb": 1
+        "3g.90gb": 1
     # GH200 144G HBM3e
     - device-filter: [ "0x234810DE" ]
       devices: all
@@ -271,6 +279,19 @@ mig-configs:
       mig-devices:
         "1g.18gb+me": 1
 
+  # B200
+  all-1g.23gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.23gb": 7
+
+  all-1g.23gb.me:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.23gb+me": 1
+
   # H200-141GB
   all-1g.35gb:
     - devices: all
@@ -309,17 +330,35 @@ mig-configs:
       mig-devices:
         "1g.36gb": 4
 
+  all-1g.45gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.45gb": 4
+
   all-2g.36gb:
     - devices: all
       mig-enabled: true
       mig-devices:
         "2g.36gb": 3
 
+  all-2g.45gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "2g.45gb": 3
+
   all-3g.72gb:
     - devices: all
       mig-enabled: true
       mig-devices:
         "3g.72gb": 2
+
+  all-3g.90gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "3g.90gb": 2
 
   all-4g.72gb:
     - devices: all
@@ -332,3 +371,9 @@ mig-configs:
       mig-enabled: true
       mig-devices:
         "7g.144gb": 1
+
+  all-7g.180gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "7g.180gb": 1


### PR DESCRIPTION
```
$ nvidia-smi mig -lgip
+-----------------------------------------------------------------------------+
| GPU instance profiles:                                                      |
| GPU   Name             ID    Instances   Memory     P2P    SM    DEC   ENC  |
|                              Free/Total   GiB              CE    JPEG  OFA  |
|=============================================================================|
|   0  MIG 1g.23gb       19     7/7        22.00      No     18     1     0   |
|                                                             2     1     0   |
+-----------------------------------------------------------------------------+
|   0  MIG 1g.23gb+me    20     1/1        22.00      No     18     1     0   |
|                                                             2     1     1   |
+-----------------------------------------------------------------------------+
|   0  MIG 1g.45gb       15     4/4        44.25      No     30     1     0   |
|                                                             2     1     0   |
+-----------------------------------------------------------------------------+
|   0  MIG 2g.45gb       14     3/3        44.25      No     36     2     0   |
|                                                             4     2     0   |
+-----------------------------------------------------------------------------+
|   0  MIG 3g.90gb        9     2/2        89.00      No     70     3     0   |
|                                                             6     3     0   |
+-----------------------------------------------------------------------------+
|   0  MIG 7g.180gb       0     1/1        178.50     No     148    7     0   |
|                                                            16     7     1   |
+-----------------------------------------------------------------------------+
```