### PR TITLE
use the (actual) latest qemu image instead of the default

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,6 +48,8 @@ jobs:
           fetch-depth: 1024
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:master
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: build ${{ matrix.package }} packages

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -58,6 +58,8 @@ jobs:
           echo "BUILD_MULTI_ARCH_IMAGES=${GENERATE_ARTIFACTS}" >> $GITHUB_ENV
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:master
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to GitHub Container Registry


### PR DESCRIPTION
This PR should fix the recent CI failures (segfaults in the arm build) we've been observing. The root cause seems to the QEMU binary not playing nice with the latest Docker buildx version v0.21.0.  Prior to this, the GitHub actions were pulling Docker build v0.18.0. 

When looking at the source code of `docker/setup-qemu-action`, I saw that it was pulling the `latest` tag of the `tonistiigi/binfmt` image by default. When I looked this tag up on docker hub, I saw it hasn't been updated in 2 years. In this PR, we point to the `master` tag instead which was updated around 3 hours at the time of filing this PR

https://hub.docker.com/r/tonistiigi/binfmt/tags