### PR TITLE
Bump golang to 1.23.5 in the systemd service

### DIFF
--- a/deployments/systemd/install.sh
+++ b/deployments/systemd/install.sh
@@ -48,7 +48,7 @@ chmod a+rx ${PROFILED_DIR}
 
 ${DOCKER} run --rm \
 	-v ${BINARY_DIR}:/dest \
-	golang:1.22.5 \
+	golang:1.23.5 \
 	sh -c "
 	go install $MIG_PARTED_GO_GET_PATH@latest
 	mv /go/bin/nvidia-mig-parted /dest/nvidia-mig-parted


### PR DESCRIPTION
This change bumps the golang version used to build the `nvidia-mig-parted` binary for the `nvidia-mig-manager` systemd service, as it currently leads to a `go install` error because the `latest` nvidia-mig-parted requires golang 1.23.

Respective error:

```log
go: github.com/NVIDIA/mig-parted/cmd/nvidia-mig-parted@latest: github.com/NVIDIA/mig-parted@v0.12.1 requires go >= 1.23.0 (running go 1.22.2; GOTOOLCHAIN=local)
```