### PR TITLE
fix: golang version for install deployments/systemctl

### DIFF
--- a/deployments/systemd/install.sh
+++ b/deployments/systemd/install.sh
@@ -48,7 +48,7 @@ chmod a+rx ${PROFILED_DIR}
 
 ${DOCKER} run --rm \
 	-v ${BINARY_DIR}:/dest \
-	golang:1.22.5 \
+	golang:1.23 \
 	sh -c "
 	go install $MIG_PARTED_GO_GET_PATH@latest
 	mv /go/bin/nvidia-mig-parted /dest/nvidia-mig-parted


### PR DESCRIPTION
I tried to use the installation for the `deployments/systemctl` service and it failed with the following error:

```bash
go: github.com/NVIDIA/mig-parted/cmd/nvidia-mig-parted@latest: github.com/NVIDIA/mig-parted@v0.12.1 requires go >= 1.23.0 (running go 1.22.5; GOTOOLCHAIN=local)
```

The fix is to update the version of the docker image in the install.sh script and everything worked nicely afterwards. 

The `Dockerfile` in  `deployments/devel` has version 1.24.1 and in `deployments/container` it is also  1.22.8.

As I haven't tried the two others I don't want to change this without some discussion. From my point of view all the variables should point to 1.24 but I'm looking forward to see what you think. 
