### PR TITLE
Add a posttrans to ensure symlinks are kept during an upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # NVIDIA MIG Manager Changelog
 
+- Add %posttrans to the rpm spec to ensure symlinks for config.yaml and hooks.yaml are maintained during an upgrade
+
 ## v0.12.1
 - Add the 4g.90gb MIG profile for the B200 GPU
 - Bump golang/x/net to v0.36.0

--- a/deployments/systemd/packages/rpm/SPECS/nvidia-mig-manager.spec
+++ b/deployments/systemd/packages/rpm/SPECS/nvidia-mig-manager.spec
@@ -79,7 +79,7 @@ install -m 644 -t %{buildroot}/usr/lib/systemd/system %{SOURCE11}
 %dir /var/lib/nvidia-mig-manager
 /usr/lib/systemd/system/nvidia-gpu-reset.target
 
-%post
+%posttrans
 systemctl daemon-reload
 systemctl enable nvidia-mig-manager.service
 


### PR DESCRIPTION
This PR adds a %posttrans section to the rpm spec file to ensure the symlinks are kept during an upgrade. The prior fix to this did not work correctly and the symlinks were removed.

By adding the %posttrans section, this ensures the symlinks are recreated after the entire upgrade process is complete, regardless of what happened during the %preun and %post phases.

Fixes #219 