### PR TITLE
Use the correct mig partion settings for the GB200

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # NVIDIA MIG Manager Changelog
 
+- Use the correct mig partition settings for the GB200
+
 ## v0.12.2
 - Add %posttrans to the rpm spec to ensure symlinks for config.yaml and hooks.yaml are maintained during an upgrade
 - Bump golang version to v1.24.5

--- a/deployments/container/nvidia-mig-manager-example-hopper-blackwell.yaml
+++ b/deployments/container/nvidia-mig-manager-example-hopper-blackwell.yaml
@@ -243,13 +243,6 @@ data:
             "1g.12gb+me": 1
 
       all-1g.24gb:
-        # GB200 HGX
-        - device-filter: ["0x294110DE"]
-          devices: all
-          mig-enabled: true
-          mig-devices:
-            "1g.24gb": 7
-        
         # H100 NVL
         - device-filter: ["0x232110DE"]
           devices: all
@@ -276,11 +269,11 @@ data:
             "7g.94gb": 1
     
       # GB200 HGX
-      all-1g.24gb.me:
+      all-2g.23gb:
         - devices: all
           mig-enabled: true
           mig-devices:
-            "1g.24gb+me": 1
+            "2g.23gb": 3
 
       all-1g.47gb:
         - devices: all
@@ -294,6 +287,18 @@ data:
           mig-devices:
             "2g.47gb": 3
 
+      all-3g.93gb:
+        - devices: all
+          mig-enabled: true
+          mig-devices:
+            "3g.93gb": 2
+
+      all-4g.93gb:
+        - devices: all
+          mig-enabled: true
+          mig-devices:
+            "4g.93gb": 1
+
       all-3g.95gb:
         - devices: all
           mig-enabled: true
@@ -305,6 +310,12 @@ data:
           mig-enabled: true
           mig-devices:
             "4g.95gb": 1
+
+      all-7g.186gb:
+        - devices: all
+          mig-enabled: true
+          mig-devices:
+            "7g.186gb": 1
 
       all-7g.189gb:
         - devices: all
@@ -319,9 +330,9 @@ data:
           devices: all
           mig-enabled: true
           mig-devices:
-            "1g.24gb": 2
+            "1g.23gb": 2
             "2g.47gb": 1
-            "3g.95gb": 1
+            "3g.93gb": 1
 
         # B200
         - device-filter: ["0x290110DE"]

--- a/deployments/systemd/config-default.yaml
+++ b/deployments/systemd/config-default.yaml
@@ -200,13 +200,6 @@ mig-configs:
         "1g.12gb+me": 1
 
   all-1g.24gb:
-    # GB200 HGX
-    - device-filter: ["0x294110DE"]
-      devices: all
-      mig-enabled: true
-      mig-devices:
-        "1g.24gb": 7
-
     # H100 NVL 94GB, RTX PRO 6000 Blackwell
     - device-filter: ["0x232110DE", "0x2BB510DE"]
       devices: all
@@ -219,6 +212,44 @@ mig-configs:
       mig-enabled: true
       mig-devices:
         "2g.24gb": 3
+
+  # GB200 HGX
+
+  all-2g.23gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "2g.23gb": 3
+
+  all-1g.47gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.47gb": 4
+
+  all-2g.47gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "2g.47gb": 3
+
+  all-3g.93gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "3g.93gb": 2
+
+  all-4g.93gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "4g.93gb": 1
+
+  all-7g.186gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "7g.186gb": 1
 
   # H100 NVL, H800 NVL
   all-3g.47gb:
@@ -265,9 +296,9 @@ mig-configs:
       devices: all
       mig-enabled: true
       mig-devices:
-        "1g.24gb": 2
+        "1g.23gb": 2
         "2g.47gb": 1
-        "3g.95gb": 1
+        "3g.93gb": 1
     # RTX PRO 6000 Blackwell
     - device-filter: ["0x2BB510DE"]
       devices: all
@@ -415,12 +446,6 @@ mig-configs:
       mig-devices:
         "1g.45gb": 4
 
-  all-1g.47gb:
-    - devices: all
-      mig-enabled: true
-      mig-devices:
-        "1g.47gb": 4
-
   all-2g.36gb:
     - devices: all
       mig-enabled: true
@@ -432,12 +457,6 @@ mig-configs:
       mig-enabled: true
       mig-devices:
         "2g.45gb": 3
-
-  all-2g.47gb:
-    - devices: all
-      mig-enabled: true
-      mig-devices:
-        "2g.47gb": 3
 
   all-3g.72gb:
     - devices: all


### PR DESCRIPTION
This PR updates the values for the GB200 mig partitions. The current values do not match the setting from the production boards.

Changelog: fix

Fixes: #227 