### PR TITLE
[ubi9] bump libxml2 and sqlite-libs packages to resolve CVEs

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -74,4 +74,7 @@ jobs:
           VERSION: ${COMMIT_SHORT_SHA}
         run: |
           echo "${VERSION}"
+          if [[ "${{ matrix.dist }}" == "ubi9" ]]; then
+             echo "CVE_UPDATES=libxml2 sqlite-libs" >> $GITHUB_ENV
+          fi
           make -f deployments/container/Makefile build-${{ matrix.dist }}


### PR DESCRIPTION
Force an update of the `libxml2` and `sqlite-libs` packages.

This addresses the following CVEs

- https://access.redhat.com/security/cve/CVE-2025-6965
- https://access.redhat.com/security/cve/CVE-2025-7425