### PR TITLE
mig-profile cleanup: remove unused profile

### DIFF
--- a/deployments/container/nvidia-mig-manager-example-hopper-blackwell.yaml
+++ b/deployments/container/nvidia-mig-manager-example-hopper-blackwell.yaml
@@ -268,12 +268,11 @@ data:
           mig-devices:
             "7g.94gb": 1
     
-      # GB200 HGX
-      all-2g.23gb:
+      all-1g.24gb.me:
         - devices: all
           mig-enabled: true
           mig-devices:
-            "2g.23gb": 3
+            "1g.24gb+me": 1
 
       all-1g.47gb:
         - devices: all

--- a/deployments/systemd/config-default.yaml
+++ b/deployments/systemd/config-default.yaml
@@ -213,14 +213,14 @@ mig-configs:
       mig-devices:
         "2g.24gb": 3
 
-  # GB200 HGX
 
-  all-2g.23gb:
+  all-1g.24gb.me:
     - devices: all
       mig-enabled: true
       mig-devices:
-        "2g.23gb": 3
+        "1g.24gb+me": 1
 
+  # GB200 HGX
   all-1g.47gb:
     - devices: all
       mig-enabled: true
@@ -389,13 +389,14 @@ mig-configs:
       mig-devices:
         "1g.18gb+me": 1
 
-  # B200
+  # GB200, B200
   all-1g.23gb:
     - devices: all
       mig-enabled: true
       mig-devices:
         "1g.23gb": 7
 
+  # GB200, B200
   all-1g.23gb.me:
     - devices: all
       mig-enabled: true


### PR DESCRIPTION
This is a follow-up PR to #228

- It reverts the addition of the new MIG profile `2g.23gb`. There is no known GPU that supports this profile so far
- Add the profile `all-1g.24gb.me` that was previously removed in #228. We don't want to remove MIG profiles that were published in a release to avoid any potential breaking changes