### PR TITLE
grant image push access to github actions

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -28,6 +28,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      packages: write
     steps:
       - uses: actions/checkout@v5
         name: Check out code


### PR DESCRIPTION
This PR fixes a regression in the GH actions pipeline introduced by #246 