### PR TITLE
Build multiarch images on native GitHub runners

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,12 +39,6 @@ jobs:
         with:
           fetch-tags: true
           fetch-depth: 1024
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          image: tonistiigi/binfmt:master
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
       - name: build ${{ matrix.package }} packages
         run: |
           sudo apt-get install -y coreutils build-essential sed git bash make

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -24,7 +24,12 @@ on:
 
 jobs:
   build:
-    runs-on: linux-amd64-cpu4
+    strategy:
+      matrix:
+        arch:
+          - amd64
+          - arm64
+    runs-on: linux-${{ matrix.arch }}-cpu4
     permissions:
       contents: read
       id-token: write
@@ -51,13 +56,6 @@ jobs:
           fi
 
           echo "PUSH_ON_BUILD=${GENERATE_ARTIFACTS}" >> $GITHUB_ENV
-          echo "BUILD_MULTI_ARCH_IMAGES=${GENERATE_ARTIFACTS}" >> $GITHUB_ENV
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          image: tonistiigi/binfmt:master
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -70,8 +68,49 @@ jobs:
       - name: Build image
         env:
           IMAGE_NAME: ghcr.io/${LOWERCASE_REPO_OWNER}/k8s-mig-manager
-          VERSION: ${COMMIT_SHORT_SHA}
+          VERSION: ${COMMIT_SHORT_SHA}-${{ matrix.arch }}
           GOPROXY: ${{ steps.setup-go-proxy.outputs.goproxy-url }}
+          DOCKER_BUILD_PLATFORM_OPTIONS: "--platform=linux/${{ matrix.arch }}"
         run: |
           echo "${VERSION}"
-          make -f deployments/container/Makefile build-image
+          make -f deployments/container/Makefile build
+
+  create-manifest:
+    needs: [ build ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        name: Check out code
+      - name: Calculate build vars
+        id: vars
+        run: |
+          echo "COMMIT_SHORT_SHA=${GITHUB_SHA:0:8}" >> $GITHUB_ENV
+          echo "LOWERCASE_REPO_OWNER=$(echo "${GITHUB_REPOSITORY_OWNER}" | awk '{print tolower($0)}')" >> $GITHUB_ENV
+
+          GENERATE_ARTIFACTS="false"
+          if [[ "${{ github.actor }}" == "dependabot[bot]" ]]; then
+            GENERATE_ARTIFACTS="false"
+          elif [[ "${{ github.event_name }}" == "pull_request" && "${{ github.event.pull_request.head.repo.full_name }}" == "${{ github.repository }}" ]]; then
+            GENERATE_ARTIFACTS="true"
+          elif [[ "${{ github.event_name }}" == "push" ]]; then
+            GENERATE_ARTIFACTS="true"
+          fi
+
+          echo "GENERATE_ARTIFACTS=${GENERATE_ARTIFACTS}" >> $GITHUB_ENV
+      - name: Login to GitHub Container Registry
+        if: ${{ env.GENERATE_ARTIFACTS == 'true' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build Manifest
+        if: ${{ env.GENERATE_ARTIFACTS == 'true' }}
+        env:
+          MULTIARCH_IMAGE: ghcr.io/${{ env.LOWERCASE_REPO_OWNER }}/k8s-mig-manager:${{ env.COMMIT_SHORT_SHA }}
+        run: |
+          docker manifest create \
+            ${MULTIARCH_IMAGE} \
+            ghcr.io/${{ env.LOWERCASE_REPO_OWNER }}/k8s-mig-manager:${{ env.COMMIT_SHORT_SHA }}-amd64 \
+            ghcr.io/${{ env.LOWERCASE_REPO_OWNER }}/k8s-mig-manager:${{ env.COMMIT_SHORT_SHA }}-arm64
+          docker manifest push ${MULTIARCH_IMAGE}

--- a/deployments/container/Makefile
+++ b/deployments/container/Makefile
@@ -14,10 +14,6 @@
 
 BUILD_MULTI_ARCH_IMAGES ?= no
 DOCKER ?= docker
-BUILDX  =
-ifeq ($(BUILD_MULTI_ARCH_IMAGES),true)
-BUILDX = buildx
-endif
 MKDIR    ?= mkdir
 DIST_DIR ?= $(CURDIR)/dist
 
@@ -45,11 +41,12 @@ GOPROXY ?= https://proxy.golang.org,direct
 DEFAULT_PUSH_TARGET := image
 DISTRIBUTIONS := $(DEFAULT_PUSH_TARGET)
 
+IMAGE_TARGETS := $(patsubst %,image-%,$(DISTRIBUTIONS))
 BUILD_TARGETS := $(patsubst %,build-%,$(DISTRIBUTIONS))
 PUSH_TARGETS := $(patsubst %,push-%,$(DISTRIBUTIONS))
 TEST_TARGETS := $(patsubst %,test-%, $(DISTRIBUTIONS))
 
-.PHONY: $(DISTRIBUTIONS) $(PUSH_TARGETS) $(BUILD_TARGETS) $(TEST_TARGETS)
+.PHONY: $(DISTRIBUTIONS) $(PUSH_TARGETS) $(BUILD_TARGETS) $(TEST_TARGETS) $(IMAGE_TARGETS)
 
 ifneq ($(BUILD_MULTI_ARCH_IMAGES),true)
 include $(CURDIR)/deployments/container/native-only.mk
@@ -59,10 +56,9 @@ endif
 
 DOCKERFILE = $(CURDIR)/deployments/container/Dockerfile
 
-# Use a generic build target to build the relevant images
-$(BUILD_TARGETS): build-%: $(ARTIFACTS_ROOT)
-	DOCKER_BUILDKIT=1 \
-		$(DOCKER) $(BUILDX) build --pull \
+# Use a generic image target to build the relevant images
+$(IMAGE_TARGETS): image-%: $(ARTIFACTS_ROOT)
+	$(DOCKER) build --pull \
 		$(DOCKER_BUILD_OPTIONS) \
 		$(DOCKER_BUILD_PLATFORM_OPTIONS) \
 		--tag $(IMAGE) \
@@ -74,3 +70,8 @@ $(BUILD_TARGETS): build-%: $(ARTIFACTS_ROOT)
 		--build-arg GOPROXY="$(GOPROXY)" \
 		-f $(DOCKERFILE) \
 		$(CURDIR)
+
+# Handle the default build target.
+.PHONY: build
+build: $(DEFAULT_PUSH_TARGET)
+$(DEFAULT_PUSH_TARGET): build-$(DEFAULT_PUSH_TARGET)

--- a/deployments/container/multi-arch.mk
+++ b/deployments/container/multi-arch.mk
@@ -15,7 +15,7 @@
 PUSH_ON_BUILD ?= false
 ATTACH_ATTESTATIONS ?= false
 DOCKER_BUILD_OPTIONS = --output=type=image,push=$(PUSH_ON_BUILD) --provenance=$(ATTACH_ATTESTATIONS) --sbom=$(ATTACH_ATTESTATIONS)
-DOCKER_BUILD_PLATFORM_OPTIONS = --platform=linux/amd64,linux/arm64
+DOCKER_BUILD_PLATFORM_OPTIONS ?= --platform=linux/amd64,linux/arm64
 
 REGCTL ?= regctl
 $(PUSH_TARGETS): push-%:

--- a/deployments/container/native-only.mk
+++ b/deployments/container/native-only.mk
@@ -12,7 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-DOCKER_BUILD_PLATFORM_OPTIONS = --platform=linux/amd64
+PUSH_ON_BUILD ?= false
+DOCKER_BUILD_PLATFORM_OPTIONS ?= --platform=linux/amd64
+
+ifeq ($(PUSH_ON_BUILD),true)
+$(BUILD_TARGETS): build-%: image-%
+	$(DOCKER) push "$(IMAGE)"
+else
+$(BUILD_TARGETS): build-%: image-%
+endif
 
 $(PUSH_TARGETS): push-%:
 	$(DOCKER) tag "$(IMAGE)" "$(OUT_IMAGE)"


### PR DESCRIPTION
This commit makes the following changes:

1. Builds multiarch images for non-release commits/PRs, in addition to released versions.
2. Runs the docker build for an arch on the respective GitHub runner (e.g. a linux/amd64 docker image will be built on a linux/amd64 runner). This native build reduces build times due to not requiring emulation.
3. Removes explicit use if buildx for docker build. Buildx is now the default builder in Docker. Also removes the related QEMU setup.