### PR TITLE
Build multi arch packages on native GitHub runners

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,9 +23,11 @@ on:
 
 jobs:
   packages:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
+        arch:
+          - amd64
+          - arm64
         package:
           - deb
           - rpm
@@ -33,6 +35,7 @@ jobs:
         ispr:
           - ${{github.event_name == 'pull_request'}}
       fail-fast: false
+    runs-on: linux-${{ matrix.arch }}-cpu4
     steps:
       - uses: actions/checkout@v5
         name: Check out code
@@ -43,10 +46,10 @@ jobs:
         run: |
           sudo apt-get install -y coreutils build-essential sed git bash make
           echo "Building packages"
-          make -f deployments/systemd/packages/Makefile ${{ matrix.package }}
+          make -f deployments/systemd/packages/Makefile ${{ matrix.package }}-${{ matrix.arch }}
       - name: 'Upload Artifacts'
         uses: actions/upload-artifact@v4
         with:
           compression-level: 0
-          name: mig-parted-${{ matrix.package }}-${{ github.run_id }}
+          name: mig-parted-${{ matrix.package }}-${{ matrix.arch }}-${{ github.run_id }}
           path: ${{ github.workspace }}/dist/*

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -23,7 +23,7 @@ on:
       - release-*
 
 jobs:
-  build:
+  image:
     strategy:
       matrix:
         arch:
@@ -76,7 +76,7 @@ jobs:
           make -f deployments/container/Makefile build
 
   create-manifest:
-    needs: [ build ]
+    needs: [ image ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/deployments/systemd/packages/Makefile
+++ b/deployments/systemd/packages/Makefile
@@ -48,11 +48,9 @@ tarball-%: DOCKERFILE = $(CURDIR)/deployments/systemd/packages/Dockerfile.tarbal
 ##### Public rules #####
 
 TARGETS = tarball deb rpm
-$(TARGETS): %: %-amd64 %-arm64
 
 AMD64_TARGETS = $(patsubst %,%-amd64,$(TARGETS))
 ARM64_TARGETS = $(patsubst %,%-arm64,$(TARGETS))
-
 
 $(AMD64_TARGETS): ARCH = amd64
 $(ARM64_TARGETS): ARCH = arm64
@@ -65,7 +63,6 @@ all: $(VALID_TARGETS)
 $(VALID_TARGETS): %:
 	@echo "Building for $(TARGET_PLATFORM)"
 	docker pull --platform=linux/$(ARCH) $(BASE_IMAGE)
-	DOCKER_BUILDKIT=1 \
 	$(DOCKER) build --pull \
 		--platform=linux/$(ARCH) \
 		--build-arg BASE_IMAGE=$(BASE_IMAGE) \


### PR DESCRIPTION
Like how we build images on native runners, this change builds packages (dep, rpm, tarballs) on native runners.