### PR TITLE
Remove references to deprecated dcgm.service

### DIFF
--- a/deployments/container/nvidia-mig-manager-example.yaml
+++ b/deployments/container/nvidia-mig-manager-example.yaml
@@ -118,7 +118,6 @@ data:
       - nvsm-notifier.service
       - nv_peer_mem.service
       - nvidia-dcgm.service
-      - dcgm.service
       - dcgm-exporter.service
 ---
 apiVersion: v1

--- a/deployments/systemd/hooks.sh
+++ b/deployments/systemd/hooks.sh
@@ -20,7 +20,6 @@ source ${CURRDIR}/utils.sh
 
 driver_services=(
 	nvsm.service
-	dcgm.service
 	nvidia-dcgm.service
 )
 


### PR DESCRIPTION
In DCGM 4.x, the legacy dcgm.service systemd unit has been replaced by an alias to the nvidia-dcgm.service systemd unit. We do not need the legacy service as dependency anymore.