### PR TITLE
Disable provenance generation during docker build

### DIFF
--- a/deployments/container/native-only.mk
+++ b/deployments/container/native-only.mk
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 PUSH_ON_BUILD ?= false
+ATTACH_ATTESTATIONS ?= false
+DOCKER_BUILD_OPTIONS = --output=type=image,push=$(PUSH_ON_BUILD) --provenance=$(ATTACH_ATTESTATIONS) --sbom=$(ATTACH_ATTESTATIONS)
 DOCKER_BUILD_PLATFORM_OPTIONS ?= --platform=linux/amd64
 
 ifeq ($(PUSH_ON_BUILD),true)


### PR DESCRIPTION
Newer Docker versions in CI enables provenance by default, which creates issues during manifest generation from multi arch images.