### PR TITLE
Remove references to config-default.yaml in rpm/deb/tarball builds

### DIFF
--- a/deployments/systemd/packages/Dockerfile.tarball
+++ b/deployments/systemd/packages/Dockerfile.tarball
@@ -79,7 +79,6 @@ ENV DESTDIR=/${PACKAGE_NAME}-${PACKAGE_VERSION_STRING}
 COPY ./LICENSE .
 COPY --from=go-build /artifacts/nvidia-mig-parted .
 COPY ./deployments/systemd/packages/tarball/install.sh ${DESTDIR}
-COPY ./deployments/systemd/config-default.yaml ${DESTDIR}
 COPY ./deployments/systemd/hooks.sh ${DESTDIR}
 COPY ./deployments/systemd/hooks-default.yaml ${DESTDIR}
 COPY ./deployments/systemd/hooks-minimal.yaml ${DESTDIR}

--- a/deployments/systemd/packages/debian/Makefile
+++ b/deployments/systemd/packages/debian/Makefile
@@ -23,8 +23,7 @@ SOURCE6 = utils.sh
 SOURCE7 = hooks.sh
 SOURCE8 = hooks-default.yaml
 SOURCE9 = hooks-minimal.yaml
-SOURCE10 = config-default.yaml
-SOURCE11 = nvidia-gpu-reset.target
+SOURCE10 = nvidia-gpu-reset.target
 
 build:
 
@@ -45,5 +44,4 @@ install:
 	install -m 644 -t $(DESTDIR)/etc/nvidia-mig-manager $(SOURCE7)
 	install -m 644 -t $(DESTDIR)/etc/nvidia-mig-manager $(SOURCE8)
 	install -m 644 -t $(DESTDIR)/etc/nvidia-mig-manager $(SOURCE9)
-	install -m 644 -t $(DESTDIR)/etc/nvidia-mig-manager $(SOURCE10)
-	install -m 644 -t $(DESTDIR)/lib/systemd/system $(SOURCE11)
+	install -m 644 -t $(DESTDIR)/lib/systemd/system $(SOURCE10)

--- a/deployments/systemd/packages/debian/postinst
+++ b/deployments/systemd/packages/debian/postinst
@@ -23,17 +23,9 @@ function maybe_add_hooks_symlink() {
   fi
 }
 
-function maybe_add_config_symlink() {
-  if [ -e /etc/nvidia-mig-manager/config.yaml ]; then
-    return
-  fi
-  ln -s config-default.yaml /etc/nvidia-mig-manager/config.yaml
-}
-
 case "${1}" in
   configure)
     maybe_add_hooks_symlink
-    maybe_add_config_symlink
   ;;
 
   abort-upgrade|abort-remove|abort-deconfigure)

--- a/deployments/systemd/packages/debian/postrm
+++ b/deployments/systemd/packages/debian/postrm
@@ -15,17 +15,9 @@ function maybe_remove_hooks_symlink() {
   fi
 }
 
-function maybe_remove_config_symlink() {
-  local target=$(readlink -f /etc/nvidia-mig-manager/config.yaml)
-  if [ "${target}" = "/etc/nvidia-mig-manager/config-default.yaml" ]; then
-    rm -rf /etc/nvidia-mig-manager/config.yaml
-  fi
-}
-
 case "${1}" in
   purge)
     maybe_remove_hooks_symlink
-    maybe_remove_config_symlink
   ;;
 
   remove|upgrade|disappear)

--- a/deployments/systemd/packages/rpm/SPECS/nvidia-mig-manager.spec
+++ b/deployments/systemd/packages/rpm/SPECS/nvidia-mig-manager.spec
@@ -18,8 +18,7 @@ Source6: utils.sh
 Source7: hooks.sh
 Source8: hooks-default.yaml
 Source9: hooks-minimal.yaml
-Source10: config-default.yaml
-Source11: nvidia-gpu-reset.target
+Source10: nvidia-gpu-reset.target
 
 %description
 The NVIDIA MIG Partition Editor allows administrators to declaratively define a
@@ -39,7 +38,7 @@ cp %{SOURCE0} %{SOURCE1} \
    %{SOURCE4} %{SOURCE5} \
    %{SOURCE6} %{SOURCE7} \
    %{SOURCE8} %{SOURCE9} \
-   %{SOURCE10} %{SOURCE11} \
+   %{SOURCE10} \
     .
 
 %install
@@ -59,8 +58,7 @@ install -m 644 -t %{buildroot}/etc/nvidia-mig-manager %{SOURCE6}
 install -m 644 -t %{buildroot}/etc/nvidia-mig-manager %{SOURCE7}
 install -m 644 -t %{buildroot}/etc/nvidia-mig-manager %{SOURCE8}
 install -m 644 -t %{buildroot}/etc/nvidia-mig-manager %{SOURCE9}
-install -m 644 -t %{buildroot}/etc/nvidia-mig-manager %{SOURCE10}
-install -m 644 -t %{buildroot}/usr/lib/systemd/system %{SOURCE11}
+install -m 644 -t %{buildroot}/usr/lib/systemd/system %{SOURCE10}
 
 %files
 %license LICENSE
@@ -71,7 +69,6 @@ install -m 644 -t %{buildroot}/usr/lib/systemd/system %{SOURCE11}
 /etc/nvidia-mig-manager/service.sh
 /etc/nvidia-mig-manager/utils.sh
 /etc/nvidia-mig-manager/hooks.sh
-/etc/nvidia-mig-manager/config-default.yaml
 /etc/nvidia-mig-manager/hooks-default.yaml
 /etc/nvidia-mig-manager/hooks-minimal.yaml
 %dir /etc/systemd/system/nvidia-mig-manager.service.d
@@ -101,15 +98,7 @@ function maybe_add_hooks_symlink() {
   fi
 }
 
-function maybe_add_config_symlink() {
-  if [ -e /etc/nvidia-mig-manager/config.yaml ]; then
-    return
-  fi
-  ln -s config-default.yaml /etc/nvidia-mig-manager/config.yaml
-}
-
 maybe_add_hooks_symlink
-maybe_add_config_symlink
 
 %preun
 function maybe_remove_hooks_symlink() {
@@ -122,19 +111,11 @@ function maybe_remove_hooks_symlink() {
   fi
 }
 
-function maybe_remove_config_symlink() {
-  local target=$(readlink -f /etc/nvidia-mig-manager/config.yaml)
-  if [ "${target}" = "/etc/nvidia-mig-manager/config-default.yaml" ]; then
-    rm -rf /etc/nvidia-mig-manager/config.yaml
-  fi
-}
-
 if [ $1 -eq 0 ]
 then
   systemctl disable nvidia-mig-manager.service
   systemctl daemon-reload
   maybe_remove_hooks_symlink
-  maybe_remove_config_symlink
 fi
 
 %changelog

--- a/deployments/systemd/packages/tarball/install.sh
+++ b/deployments/systemd/packages/tarball/install.sh
@@ -50,7 +50,6 @@ cp utils.sh              ${CONFIG_DIR}
 cp hooks.sh              ${CONFIG_DIR}
 cp hooks-default.yaml    ${CONFIG_DIR}
 cp hooks-minimal.yaml    ${CONFIG_DIR}
-cp config-default.yaml    ${CONFIG_DIR}
 
 chmod a+r ${SYSTEMD_DIR}/${SERVICE_NAME}
 chmod a+r ${PROFILED_DIR}/${MIG_PARTED_NAME}.sh
@@ -60,7 +59,6 @@ chmod a+r ${CONFIG_DIR}/utils.sh
 chmod a+r ${CONFIG_DIR}/hooks.sh
 chmod a+r ${CONFIG_DIR}/hooks-default.yaml
 chmod a+r ${CONFIG_DIR}/hooks-minimal.yaml
-chmod a+r ${CONFIG_DIR}/config-default.yaml
 
 chmod a+x ${BINARY_DIR}/${MIG_PARTED_NAME}
 chmod ug+x ${CONFIG_DIR}/service.sh
@@ -86,12 +84,4 @@ function maybe_add_hooks_symlink() {
   fi
 }
 
-function maybe_add_config_symlink() {
-  if [ -e ${CONFIG_DIR}/config.yaml ]; then
-    return
-  fi
-  ln -s config-default.yaml ${CONFIG_DIR}/config.yaml
-}
-
 maybe_add_hooks_symlink
-maybe_add_config_symlink


### PR DESCRIPTION
These were missed when dynamic MIG config changes were made.

Tested by running `make -f deployments/systemd/packages/Makefile {rpm,deb,tarball}-{amd64,arm64}` locally. These builds are only run in CI after merge. 