### PR TITLE
Fallback to static MIG config when profiles are not discovered

### DIFF
--- a/deployments/systemd/config-default.yaml
+++ b/deployments/systemd/config-default.yaml
@@ -1,0 +1,613 @@
+version: v1
+mig-configs:
+  all-disabled:
+    - devices: all
+      mig-enabled: false
+
+  all-enabled:
+    - devices: all
+      mig-enabled: true
+      mig-devices: {}
+
+  # A100-40GB, A800-40GB
+  all-1g.5gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.5gb": 7
+
+  all-1g.5gb.me:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.5gb+me": 1
+
+  all-2g.10gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "2g.10gb": 3
+
+  all-3g.20gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "3g.20gb": 2
+
+  all-4g.20gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "4g.20gb": 1
+
+  all-7g.40gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "7g.40gb": 1
+
+  # RTX PRO 6000 Blackwell
+  all-1g.24gb.gfx:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.24gb+gfx": 4
+
+  all-1g.24gb.me.all:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.24gb+me.all": 1
+
+  all-1g.24gb-me:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.24gb-me": 4
+
+  all-2g.48gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "2g.48gb": 2
+
+  all-2g.48gb.gfx:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "2g.48gb+gfx": 2
+
+  all-2g.48gb.me.all:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "2g.48gb+me.all": 1
+
+  all-2g.48gb-me:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "2g.48gb-me": 2
+
+  all-4g.96gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "4g.96gb": 1
+
+  all-4g.96gb.gfx:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "4g.96gb+gfx": 1
+
+  # H100-80GB, H800-80GB, A100-80GB, A800-80GB, A100-40GB, A800-40GB
+  all-1g.10gb:
+    # H100-80GB, H800-80GB, A100-80GB, A800-80GB
+    - device-filter: ["0x233010DE", "0x233110DE", "0x232210DE", "0x20B210DE", "0x20B510DE", "0x20F310DE", "0x20F510DE", "0x232410DE"]
+      devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.10gb": 7
+
+    # A100-40GB, A800-40GB
+    - device-filter: ["0x20B010DE", "0x20B110DE", "0x20F110DE", "0x20F610DE"]
+      devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.10gb": 4
+
+  # H100-80GB, H800-80GB, A100-80GB, A800-80GB
+  all-1g.10gb.me:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.10gb+me": 1
+
+  # H100-80GB, H800-80GB, A100-80GB, A800-80GB
+  all-1g.20gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.20gb": 4
+
+  all-2g.20gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "2g.20gb": 3
+
+  all-3g.40gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "3g.40gb": 2
+
+  all-4g.40gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "4g.40gb": 1
+
+  all-7g.80gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "7g.80gb": 1
+
+  # A30-24GB
+  all-1g.6gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.6gb": 4
+
+  all-1g.6gb.me:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.6gb+me": 1
+
+  all-2g.12gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "2g.12gb": 2
+
+  all-2g.12gb.me:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "2g.12gb+me": 1
+
+  all-4g.24gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "4g.24gb": 1
+
+  # H100 NVL, H800 NVL, GH200
+  all-1g.12gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.12gb": 7
+
+  all-1g.12gb.me:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.12gb+me": 1
+
+  all-1g.24gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.24gb": 4
+
+  all-2g.24gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "2g.24gb": 3
+
+
+  all-1g.24gb.me:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.24gb+me": 1
+
+  # GB200 HGX
+  all-1g.47gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.47gb": 4
+
+  all-2g.47gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "2g.47gb": 3
+
+  all-3g.93gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "3g.93gb": 2
+
+  all-4g.93gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "4g.93gb": 1
+
+  all-7g.186gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "7g.186gb": 1
+
+  # H100 NVL, H800 NVL
+  all-3g.47gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "3g.47gb": 2
+
+  all-4g.47gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "4g.47gb": 1
+
+  all-7g.94gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "7g.94gb": 1
+
+  # H100-96GB, PG506-96GB, GH200
+  all-3g.48gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "3g.48gb": 2
+
+  all-4g.48gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "4g.48gb": 1
+
+  all-7g.96gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "7g.96gb": 1
+
+  # GB200 HGX, B200, GH200 144G HBM3e, H200-141GB, H200 NVL, H100-96GB, GH200, H100 NVL, H800 NVL, H100-80GB, H800-80GB, A800-40GB, A800-80GB, A100-40GB, A100-80GB, A30-24GB, PG506-96GB
+  all-balanced:
+    # GB200 HGX
+    - device-filter: ["0x294110DE"]
+      devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.23gb": 2
+        "2g.47gb": 1
+        "3g.93gb": 1
+    # GB300
+    - device-filter: ["0x31C210DE"]
+      devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.35gb": 2
+        "2g.70gb": 1
+        "3g.139gb": 1
+    # RTX PRO 6000 Blackwell
+    - device-filter: ["0x2BB510DE"]
+      devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.24gb": 2
+        "2g.48gb": 1
+    # B200
+    - device-filter: [ "0x290110DE" ]
+      devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.23gb": 2
+        "2g.45gb": 1
+        "3g.90gb": 1
+    # B300
+    - device-filter: ["0x318210DE"]
+      devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.34gb": 2
+        "2g.67gb": 1
+        "3g.135gb": 1
+    # GH200 144G HBM3e
+    - device-filter: [ "0x234810DE" ]
+      devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.18gb": 2
+        "2g.36gb": 1
+        "3g.72gb": 1
+
+    # H200 141GB, H200 NVL
+    - device-filter: ["0x233510DE", "0x233B10DE"]
+      devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.18gb": 2
+        "2g.35gb": 1
+        "3g.71gb": 1
+
+    # H100 NVL, H800 NVL
+    - device-filter: ["0x232110DE", "0x233A10DE"]
+      devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.12gb": 2
+        "2g.24gb": 1
+        "3g.47gb": 1
+
+    # H100-80GB, H800-80GB, A100-80GB, A800-80GB
+    - device-filter: ["0x233010DE", "0x233110DE", "0x232210DE", "0x20B210DE", "0x20B510DE", "0x20F310DE", "0x20F510DE", "0x232410DE"]
+      devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.10gb": 2
+        "2g.20gb": 1
+        "3g.40gb": 1
+
+    # A100-40GB, A800-40GB
+    - device-filter: ["0x20B010DE", "0x20B110DE", "0x20F110DE", "0x20F610DE"]
+      devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.5gb": 2
+        "2g.10gb": 1
+        "3g.20gb": 1
+
+    # A30-24GB
+    - device-filter: "0x20B710DE"
+      devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.6gb": 2
+        "2g.12gb": 1
+
+    # H100-96GB, PG506-96GB, GH200, H20
+    - device-filter: ["0x234210DE", "0x233D10DE", "0x20B610DE", "0x232910DE"]
+      devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.12gb": 2
+        "2g.24gb": 1
+        "3g.48gb": 1
+
+  # H200-141GB, GH200 144G HBM3e
+  all-1g.18gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.18gb": 7
+
+  all-1g.18gb.me:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.18gb+me": 1
+
+  # GB200, B200
+  all-1g.23gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.23gb": 7
+
+  # GB200, B200
+  all-1g.23gb.me:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.23gb+me": 1
+
+  all-1g.35gb:
+    # H200-141GB
+    - device-filter: ["0x233510DE"]
+      devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.35gb": 4
+    # GB300
+    - device-filter: ["0x31C210DE"]
+      devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.35gb": 7
+
+  all-2g.35gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "2g.35gb": 3
+
+  all-3g.71gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "3g.71gb": 2
+
+  all-4g.71gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "4g.71gb": 1
+
+  all-7g.141gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "7g.141gb": 1
+
+  all-1g.34gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.34gb": 7
+
+  all-1g.34gb.me:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.34gb+me": 1
+
+  all-1g.35gb.me:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.35gb+me": 1
+
+  # GH200 144G HBM3e
+  all-1g.36gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.36gb": 4
+
+  all-1g.45gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.45gb": 4
+
+  all-1g.67gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.67gb": 4
+
+  all-1g.70gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "1g.70gb": 4
+
+  all-2g.36gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "2g.36gb": 3
+
+  all-2g.45gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "2g.45gb": 3
+
+  all-2g.67gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "2g.67gb": 3
+
+  all-2g.70gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "2g.70gb": 3
+
+  all-3g.72gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "3g.72gb": 2
+
+  all-3g.90gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "3g.90gb": 2
+
+  all-3g.95gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "3g.95gb": 2
+
+  all-3g.135gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "3g.135gb": 2
+
+  all-3g.139gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "3g.139gb": 2
+
+  all-4g.72gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "4g.72gb": 1
+
+  all-4g.90gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "4g.90gb": 1
+
+  all-4g.95gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "4g.95gb": 1
+
+  all-4g.135gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "4g.135gb": 1
+
+  all-4g.139gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "4g.139gb": 1
+
+  all-7g.144gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "7g.144gb": 1
+
+  all-7g.180gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "7g.180gb": 1
+
+  all-7g.189gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "7g.189gb": 1
+
+  all-7g.269gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "7g.269gb": 1
+
+  all-7g.278gb:
+    - devices: all
+      mig-enabled: true
+      mig-devices:
+        "7g.278gb": 1

--- a/deployments/systemd/packages/Dockerfile.tarball
+++ b/deployments/systemd/packages/Dockerfile.tarball
@@ -82,6 +82,7 @@ COPY ./deployments/systemd/packages/tarball/install.sh ${DESTDIR}
 COPY ./deployments/systemd/hooks.sh ${DESTDIR}
 COPY ./deployments/systemd/hooks-default.yaml ${DESTDIR}
 COPY ./deployments/systemd/hooks-minimal.yaml ${DESTDIR}
+COPY ./deployments/systemd/config-default.yaml ${DESTDIR}
 COPY ./deployments/systemd/nvidia-mig-manager.service ${DESTDIR}
 COPY ./deployments/systemd/nvidia-gpu-reset.target ${DESTDIR}
 COPY ./deployments/systemd/nvidia-mig-parted.sh ${DESTDIR}

--- a/deployments/systemd/packages/debian/Makefile
+++ b/deployments/systemd/packages/debian/Makefile
@@ -23,7 +23,8 @@ SOURCE6 = utils.sh
 SOURCE7 = hooks.sh
 SOURCE8 = hooks-default.yaml
 SOURCE9 = hooks-minimal.yaml
-SOURCE10 = nvidia-gpu-reset.target
+SOURCE10 = config-default.yaml
+SOURCE11 = nvidia-gpu-reset.target
 
 build:
 
@@ -44,4 +45,5 @@ install:
 	install -m 644 -t $(DESTDIR)/etc/nvidia-mig-manager $(SOURCE7)
 	install -m 644 -t $(DESTDIR)/etc/nvidia-mig-manager $(SOURCE8)
 	install -m 644 -t $(DESTDIR)/etc/nvidia-mig-manager $(SOURCE9)
-	install -m 644 -t $(DESTDIR)/lib/systemd/system $(SOURCE10)
+	install -m 644 -t $(DESTDIR)/etc/nvidia-mig-manager $(SOURCE10)
+	install -m 644 -t $(DESTDIR)/lib/systemd/system $(SOURCE11)

--- a/deployments/systemd/packages/debian/postrm
+++ b/deployments/systemd/packages/debian/postrm
@@ -18,6 +18,8 @@ function maybe_remove_hooks_symlink() {
 case "${1}" in
   purge)
     maybe_remove_hooks_symlink
+    # Remove runtime-generated config (not tracked by dpkg)
+    rm -f /etc/nvidia-mig-manager/config.yaml
   ;;
 
   remove|upgrade|disappear)

--- a/deployments/systemd/packages/rpm/SPECS/nvidia-mig-manager.spec
+++ b/deployments/systemd/packages/rpm/SPECS/nvidia-mig-manager.spec
@@ -18,7 +18,8 @@ Source6: utils.sh
 Source7: hooks.sh
 Source8: hooks-default.yaml
 Source9: hooks-minimal.yaml
-Source10: nvidia-gpu-reset.target
+Source10: config-default.yaml
+Source11: nvidia-gpu-reset.target
 
 %description
 The NVIDIA MIG Partition Editor allows administrators to declaratively define a
@@ -38,7 +39,7 @@ cp %{SOURCE0} %{SOURCE1} \
    %{SOURCE4} %{SOURCE5} \
    %{SOURCE6} %{SOURCE7} \
    %{SOURCE8} %{SOURCE9} \
-   %{SOURCE10} \
+   %{SOURCE10} %{SOURCE11} \
     .
 
 %install
@@ -58,7 +59,8 @@ install -m 644 -t %{buildroot}/etc/nvidia-mig-manager %{SOURCE6}
 install -m 644 -t %{buildroot}/etc/nvidia-mig-manager %{SOURCE7}
 install -m 644 -t %{buildroot}/etc/nvidia-mig-manager %{SOURCE8}
 install -m 644 -t %{buildroot}/etc/nvidia-mig-manager %{SOURCE9}
-install -m 644 -t %{buildroot}/usr/lib/systemd/system %{SOURCE10}
+install -m 644 -t %{buildroot}/etc/nvidia-mig-manager %{SOURCE10}
+install -m 644 -t %{buildroot}/usr/lib/systemd/system %{SOURCE11}
 
 %files
 %license LICENSE
@@ -71,6 +73,7 @@ install -m 644 -t %{buildroot}/usr/lib/systemd/system %{SOURCE10}
 /etc/nvidia-mig-manager/hooks.sh
 /etc/nvidia-mig-manager/hooks-default.yaml
 /etc/nvidia-mig-manager/hooks-minimal.yaml
+/etc/nvidia-mig-manager/config-default.yaml
 %dir /etc/systemd/system/nvidia-mig-manager.service.d
 %dir /etc/nvidia-mig-manager/
 %dir /var/lib/nvidia-mig-manager
@@ -116,6 +119,8 @@ then
   systemctl disable nvidia-mig-manager.service
   systemctl daemon-reload
   maybe_remove_hooks_symlink
+  # Remove runtime-generated config (not tracked by RPM)
+  rm -f /etc/nvidia-mig-manager/config.yaml
 fi
 
 %changelog

--- a/deployments/systemd/packages/tarball/install.sh
+++ b/deployments/systemd/packages/tarball/install.sh
@@ -50,6 +50,7 @@ cp utils.sh              ${CONFIG_DIR}
 cp hooks.sh              ${CONFIG_DIR}
 cp hooks-default.yaml    ${CONFIG_DIR}
 cp hooks-minimal.yaml    ${CONFIG_DIR}
+cp config-default.yaml   ${CONFIG_DIR}
 
 chmod a+r ${SYSTEMD_DIR}/${SERVICE_NAME}
 chmod a+r ${PROFILED_DIR}/${MIG_PARTED_NAME}.sh
@@ -59,6 +60,7 @@ chmod a+r ${CONFIG_DIR}/utils.sh
 chmod a+r ${CONFIG_DIR}/hooks.sh
 chmod a+r ${CONFIG_DIR}/hooks-default.yaml
 chmod a+r ${CONFIG_DIR}/hooks-minimal.yaml
+chmod a+r ${CONFIG_DIR}/config-default.yaml
 
 chmod a+x ${BINARY_DIR}/${MIG_PARTED_NAME}
 chmod ug+x ${CONFIG_DIR}/service.sh


### PR DESCRIPTION
Older drivers such as R535 does not support querying MIG profiles when MIG mode is disabled. This change restores the static config that was previously removed, so MIG manager can fallback to that config when generation is not possible.