### PR TITLE
Fix hooks not running when invoked via systemd service

### DIFF
--- a/deployments/systemd/service.sh
+++ b/deployments/systemd/service.sh
@@ -46,9 +46,11 @@ fi
 rm -f "${CONFIG_FILE}.tmp"
 
 : "${MIG_PARTED_CONFIG_FILE:=${CONFIG_FILE}}"
+: "${MIG_PARTED_HOOKS_FILE:=${CURRDIR}/hooks.yaml}"
 : "${MIG_PARTED_SELECTED_CONFIG:?Environment variable must be set before calling this script}"
 
 export MIG_PARTED_CONFIG_FILE
+export MIG_PARTED_HOOKS_FILE
 export MIG_PARTED_SELECTED_CONFIG
 
 set -x


### PR DESCRIPTION
`service.sh` defaults `MIG_PARTED_CONFIG_FILE` but not `MIG_PARTED_HOOKS_FILE`. Since systemd does not source `/etc/profile.d/`, the hooks file env var is unset and all hooks silently become no-ops.