### PR TITLE
fix: Use management mode when generating CDI spec

### DIFF
--- a/pkg/mig/reconfigure/reconfigure.go
+++ b/pkg/mig/reconfigure/reconfigure.go
@@ -640,6 +640,7 @@ func (r *Reconfigure) createCDISpec() error {
 	log.Info("Creating management CDI spec (simplified implementation)")
 
 	cdiGenerateCommand := exec.Command("nvidia-ctk", "cdi", "generate",
+		"--mode=management",
 		"--driver-root="+r.opts.DriverRootCtrPath,
 		"--dev-root="+r.opts.DevRootCtrPath,
 		"--vendor=management.nvidia.com",


### PR DESCRIPTION
In migrating to go, we missed that we need to explicitly specify the CDI spec generation mode as `management` (See https://github.com/NVIDIA/mig-parted/blob/4472d371ef2dc054426b0629240c20800925ee55/deployments/container/reconfigure-mig.sh#L606). 

Also note #261 where we can specify the mode through the API.

As a workaround, the `NVIDIA_CTK_CDI_GENERATE_MODE` can be set to `management` to ensure that CDI specs are generated using the management mode.

