### PR TITLE
chroot host migPartedBinary compatibility fix

### DIFF
--- a/cmd/nvidia-mig-manager/main.go
+++ b/cmd/nvidia-mig-manager/main.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -540,8 +541,14 @@ func migReconfigure(ctx context.Context, migConfigValue string, clientset *kuber
 		if err != nil {
 			return fmt.Errorf("failed to copy nvidia-mig-parted to host: %w", err)
 		}
-		migPartedBinary = strings.Split(hostMigPartedBinary, " ")
-		opts.MigConfigFile = filepath.Join(hostNvidiaDirFlag, "mig-manager", "config.yaml")
+
+		hostMigPartedBinaryPath := filepath.Join(hostNvidiaDirFlag, "mig-manager", "nvidia-mig-parted")
+		if hostSupportsMigParted(hostRootMountFlag, hostMigPartedBinaryPath) {
+			migPartedBinary = strings.Split(hostMigPartedBinary, " ")
+			opts.MigConfigFile = filepath.Join(hostNvidiaDirFlag, "mig-manager", "config.yaml")
+		} else {
+			log.Warn("Host userspace is incompatible with the bundled nvidia-mig-parted binary, falling back to in-container execution")
+		}
 	}
 
 	rcfg, err := reconfigure.New(ctx, clientset, migPartedBinary, opts)
@@ -581,6 +588,11 @@ func ContinuouslySyncMigConfigChanges(clientset *kubernetes.Clientset, migConfig
 	stop := make(chan struct{})
 	go controller.Run(stop)
 	return stop
+}
+
+func hostSupportsMigParted(hostRootMount, hostMigPartedBinaryPath string) bool {
+	cmd := exec.Command("chroot", hostRootMount, hostMigPartedBinaryPath, "--help")
+	return cmd.Run() == nil
 }
 
 // copyMigPartedToHost copies the "nvidia-mig-parted" binary from the container's root filesystem over to that of the host's.


### PR DESCRIPTION


refer: [329](https://github.com/NVIDIA/mig-parted/issues/329)

To Reproduce:

**Method 1:** 
 Install GPU Operator:

```
helm install --wait --generate-name \
  -n gpu-operator --create-namespace \
  nvidia/gpu-operator \
  --version v26.3.0 \
  --set mig.strategy=single
```

Exec into the MIG manager pod:

`kubectl exec -it -n gpu-operator mig-manager-.... -- sh`
Copy the binary to the host mount and run it through chroot:

```
mkdir -p /host/usr/local/nvidia/mig-manager
cp /usr/bin/nvidia-mig-parted /host/usr/local/nvidia/mig-manager/
chroot /host /usr/local/nvidia/mig-manager/nvidia-mig-parted assert -f /usr/local/nvidia/mig-manager/config.yaml -c config13

```
Observe:
```
/usr/local/nvidia/mig-manager/nvidia-mig-parted: /lib64/libc.so.6: version `GLIBC_2.32' not found
/usr/local/nvidia/mig-manager/nvidia-mig-parted: /lib64/libc.so.6: version `GLIBC_2.34' not found
```

**Method: 2:** 
Reproduce through the host-driver path:

Reproduce by simulating the host chroot path manually:

Install the NVIDIA driver on the RHEL 8 host:

```
sudo dnf -y install dkms kernel-devel-$(uname -r) kernel-headers-$(uname -r) gcc make elfutils-libelf-devel
sudo dnf -y module reset nvidia-driver
sudo dnf -y module enable nvidia-driver:580-dkms
sudo dnf -y install cuda-drivers
```

Install GPU Operator:

```
helm install --wait --generate-name \
  -n gpu-operator --create-namespace \
  nvidia/gpu-operator \
  --version v26.3.0 \
  --set driver.enabled=false \
  --set mig.strategy=single
```

Check that the host-driver path is enabled: `IS_HOST_DRIVER = true ==> WITH_SHUTDOWN_HOST_GPU_CLIENTS = true`  in logs or env :

Check the MIG manager logs:

`kubectl logs -n gpu-operator nvidia-mig-manager...`

Observe:

```
/usr/local/nvidia/mig-manager/nvidia-mig-parted: /lib64/libc.so.6: version `GLIBC_2.32' not found (required by /usr/local/nvidia/mig-manager/nvidia-mig-parted)
/usr/local/nvidia/mig-manager/nvidia-mig-parted: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by /usr/local/nvidia/mig-manager/nvidia-mig-parted)
```

In your case, nvidia-driver is installed on the host, `IS_HOST_DRIVER=true,` which makes `WITH_SHUTDOWN_HOST_GPU_CLIENTS=true`. 
This causes nvidia-mig-manager to execute `nvidia-mig-parted `through the host path.
The failure is caused by a host userspace compatibility issue on `RHEL-8`: the newer `nvidia-mig-parted` binary requires a newer `glibc` than the host provides. 

working on a fix so that on older host systems nvidia-mig-manager does not execute nvidia-mig-parted through chroot. 