### PR TITLE
Switch build base image from ubi9 to ubi8

### DIFF
--- a/deployments/container/Dockerfile
+++ b/deployments/container/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM nvcr.io/nvidia/cuda:13.2.0-base-ubi9 as build
+FROM nvcr.io/nvidia/cuda:13.2.0-base-ubi8 as build
 
 SHELL ["/bin/bash", "-c"]
 


### PR DESCRIPTION
The go-nvml dependency uses CGO, so the nvidia-mig-parted binary links
against glibc at build time. Building on ubi9 (glibc 2.34) produces a
binary that requires GLIBC_2.32 and GLIBC_2.34 symbols at runtime.
When the mig-manager runs this binary on RHEL 8 hosts via chroot
(host-driver path), it fails because RHEL 8 only ships glibc 2.28.

Switch the build stage base image from ubi9 to ubi8, which ships
glibc 2.28. This ensures the compiled binary is compatible with
RHEL 8 hosts.

Fixes: #329