### PR TITLE
Add cherry-pick workflow for automated backports

### DIFF
--- a/.github/scripts/add-labels-from-comment.js
+++ b/.github/scripts/add-labels-from-comment.js
@@ -1,0 +1,110 @@
+/**
+ * Copyright NVIDIA CORPORATION
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module.exports = async ({ github, context, core }) => {
+  const commentBody = context.payload.comment.body;
+  const prNumber = context.payload.issue.number;
+
+  core.info(`Processing comment: ${commentBody}`);
+
+  // Parse comment for /cherry-pick branches
+  const cherryPickPattern = /^\/cherry-pick\s+(.+)$/m;
+  const match = commentBody.match(cherryPickPattern);
+
+  if (!match) {
+    core.warning('Comment does not match /cherry-pick pattern');
+    return { success: false, message: 'Invalid format' };
+  }
+
+  // Extract all release branches (space-separated)
+  const branchesText = match[1].trim();
+  const branchPattern = /release-\d+\.\d+(?:\.\d+)?/g;
+  const branches = branchesText.match(branchPattern) || [];
+
+  if (branches.length === 0) {
+    core.warning('No valid release branches found in comment');
+    await github.rest.reactions.createForIssueComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      comment_id: context.payload.comment.id,
+      content: 'confused'
+    });
+    return { success: false, message: 'No valid branches found' };
+  }
+
+  core.info(`Found branches: ${branches.join(', ')}`);
+
+  // Add labels to PR
+  const labels = branches.map(branch => `cherry-pick/${branch}`);
+  
+  try {
+    await github.rest.issues.addLabels({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: prNumber,
+      labels: labels
+    });
+    core.info(`Added labels: ${labels.join(', ')}`);
+  } catch (error) {
+    core.error(`Failed to add labels: ${error.message}`);
+    await github.rest.reactions.createForIssueComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      comment_id: context.payload.comment.id,
+      content: '-1'
+    });
+    return { success: false, message: error.message };
+  }
+
+  // React with checkmark emoji
+  await github.rest.reactions.createForIssueComment({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    comment_id: context.payload.comment.id,
+    content: '+1'
+  });
+
+  // Check if PR is already merged
+  const { data: pullRequest } = await github.rest.pulls.get({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    pull_number: prNumber
+  });
+
+  if (pullRequest.merged) {
+    core.info('PR is already merged - triggering backport immediately');
+    
+    // Set branches in environment and trigger backport
+    process.env.BRANCHES_JSON = JSON.stringify(branches);
+    
+    // Run backport script
+    const backportScript = require('./backport.js');
+    const results = await backportScript({ github, context, core });
+    
+    return { 
+      success: true, 
+      message: `Labels added and backport triggered for: ${branches.join(', ')}`,
+      backportResults: results
+    };
+  } else {
+    core.info('PR not yet merged - labels added, backport will trigger on merge');
+    return { 
+      success: true, 
+      message: `Labels added for: ${branches.join(', ')}. Backport will trigger on merge.`
+    };
+  }
+};
+

--- a/.github/scripts/backport.js
+++ b/.github/scripts/backport.js
@@ -1,0 +1,290 @@
+/**
+ * Copyright NVIDIA CORPORATION
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module.exports = async ({ github, context, core }) => {
+const branches = JSON.parse(process.env.BRANCHES_JSON || '[]');
+
+// Get PR number from event
+const prNumber = context.payload.pull_request?.number || context.payload.issue.number;
+
+// Fetch full PR data (needed when triggered via issue_comment)
+const { data: pullRequest } = await github.rest.pulls.get({
+  owner: context.repo.owner,
+  repo: context.repo.repo,
+  pull_number: prNumber
+});
+
+const prTitle = pullRequest.title;
+const prAuthor = pullRequest.user.login;
+
+// Get all commits from the PR
+const { data: commits } = await github.rest.pulls.listCommits({
+  owner: context.repo.owner,
+  repo: context.repo.repo,
+  pull_number: prNumber
+});
+
+if (commits.length === 0) {
+  core.warning('No commits found in PR - skipping backport');
+  return [];
+}
+
+core.info(`Backporting PR #${prNumber}: "${prTitle}"`);
+core.info(`Commits to cherry-pick: ${commits.length}`);
+commits.forEach((commit, index) => {
+  core.info(`  ${index + 1}. ${commit.sha.substring(0, 7)} - ${commit.commit.message.split('\n')[0]}`);
+});
+
+const { execSync } = require('child_process');
+
+const results = [];
+
+for (const targetBranch of branches) {
+  core.info(`\n========================================`);
+  core.info(`Backporting to ${targetBranch}`);
+  core.info(`========================================`);
+  const backportBranch = `backport-${prNumber}-to-${targetBranch}`;
+  try {
+    // Create/reset backport branch from target release branch
+    core.info(`Creating/resetting branch ${backportBranch} from ${targetBranch}`);
+    execSync(`git fetch origin ${targetBranch}:${targetBranch}`, { stdio: 'inherit' });
+    execSync(`git checkout -B ${backportBranch} ${targetBranch}`, { stdio: 'inherit' });
+    // Cherry-pick each commit from the PR
+    let hasConflicts = false;
+    for (let i = 0; i < commits.length; i++) {
+      const commit = commits[i];
+      const commitSha = commit.sha;
+      const commitMessage = commit.commit.message.split('\n')[0];
+      core.info(`Cherry-picking commit ${i + 1}/${commits.length}: ${commitSha.substring(0, 7)} - ${commitMessage}`);
+      try {
+        execSync(`git cherry-pick -m 1 -x ${commitSha}`, { 
+          encoding: 'utf-8',
+          stdio: 'pipe'
+        });
+      } catch (error) {
+        // Check if it's a conflict
+        const status = execSync('git status', { encoding: 'utf-8' });
+        if (status.includes('Unmerged paths') || status.includes('both modified')) {
+          hasConflicts = true;
+          core.warning(`Cherry-pick has conflicts for commit ${commitSha.substring(0, 7)}.`);
+          // Add all files (including conflicted ones) and commit
+          execSync('git add .', { stdio: 'inherit' });
+          try {
+            execSync(`git -c core.editor=true cherry-pick --continue`, { stdio: 'inherit' });
+          } catch (e) {
+            // If continue fails, make a simple commit
+            execSync(`git commit --no-edit --allow-empty-message || git commit -m "Cherry-pick ${commitSha} (with conflicts)"`, { stdio: 'inherit' });
+          }
+        } else if (error.message && error.message.includes('previous cherry-pick is now empty')) {
+          // Handle empty commits (changes already exist in target branch)
+          core.info(`Commit ${commitSha.substring(0, 7)} is empty (changes already in target branch), skipping`);
+          execSync('git cherry-pick --skip', { stdio: 'inherit' });
+        } else {
+          throw error;
+        }
+      }
+    }
+    // Push the backport branch (force to handle updates)
+    core.info(`Pushing ${backportBranch} to origin`);
+    execSync(`git push --force-with-lease origin ${backportBranch}`, { stdio: 'inherit' });
+    
+    // Check if a PR already exists for this backport branch
+    const { data: existingPRs } = await github.rest.pulls.list({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      head: `${context.repo.owner}:${backportBranch}`,
+      base: targetBranch,
+      state: 'open'
+    });
+    const existingPR = existingPRs.length > 0 ? existingPRs[0] : null;
+    
+    // Create pull request
+    const commitList = commits.map(c => `- \`${c.sha.substring(0, 7)}\` ${c.commit.message.split('\n')[0]}`).join('\n');
+    
+    // Build PR body based on conflict status
+    let prBody = `🤖 **Automated backport of #${prNumber} to \`${targetBranch}\`**\n\n`;
+    
+    if (hasConflicts) {
+      prBody += `⚠️ **This PR has merge conflicts that need manual resolution.**
+
+Original PR: #${prNumber}
+Original Author: @${prAuthor}
+
+**Cherry-picked commits (${commits.length}):**
+${commitList}
+
+**Next Steps:**
+1. Review the conflicts in the "Files changed" tab
+2. Check out this branch locally: \`git fetch origin ${backportBranch} && git checkout ${backportBranch}\`
+3. Resolve conflicts manually
+4. Push the resolution: \`git push --force-with-lease origin ${backportBranch}\`
+
+---
+<details>
+<summary>Instructions for resolving conflicts</summary>
+
+\`\`\`bash
+git fetch origin ${backportBranch}
+git checkout ${backportBranch}
+# Resolve conflicts in your editor
+git add .
+git commit
+git push --force-with-lease origin ${backportBranch}
+\`\`\`
+</details>`;
+    } else {
+      prBody += `✅ Cherry-pick completed successfully with no conflicts.
+
+Original PR: #${prNumber}
+Original Author: @${prAuthor}
+
+**Cherry-picked commits (${commits.length}):**
+${commitList}
+
+This backport was automatically created by the backport bot.`;
+    }
+
+    if (existingPR) {
+      // Update existing PR
+      core.info(`Found existing PR #${existingPR.number}, updating it`);
+      await github.rest.pulls.update({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        pull_number: existingPR.number,
+        body: prBody,
+        draft: hasConflicts
+      });
+      
+      // Update labels
+      const currentLabels = existingPR.labels.map(l => l.name);
+      const desiredLabels = ['backport', hasConflicts ? 'needs-manual-resolution' : 'auto-backport'];
+      
+      // Remove old labels if conflict status changed
+      if (hasConflicts && currentLabels.includes('auto-backport')) {
+        await github.rest.issues.removeLabel({
+          owner: context.repo.owner,
+          repo: context.repo.repo,
+          issue_number: existingPR.number,
+          name: 'auto-backport'
+        }).catch(() => {}); // Ignore if label doesn't exist
+      } else if (!hasConflicts && currentLabels.includes('needs-manual-resolution')) {
+        await github.rest.issues.removeLabel({
+          owner: context.repo.owner,
+          repo: context.repo.repo,
+          issue_number: existingPR.number,
+          name: 'needs-manual-resolution'
+        }).catch(() => {}); // Ignore if label doesn't exist
+      }
+      
+      // Add current labels
+      await github.rest.issues.addLabels({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: existingPR.number,
+        labels: desiredLabels
+      });
+      
+      // Comment about the update
+      await github.rest.issues.createComment({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: prNumber,
+        body: `🤖 Updated existing backport PR for \`${targetBranch}\`: #${existingPR.number} ${hasConflicts ? '⚠️ (has conflicts)' : '✅'}`
+      });
+      
+      results.push({
+        branch: targetBranch,
+        success: true,
+        prNumber: existingPR.number,
+        prUrl: existingPR.html_url,
+        hasConflicts,
+        updated: true
+      });
+      core.info(`✅ Successfully updated backport PR #${existingPR.number}`);
+    } else {
+      // Create new PR
+      const newPR = await github.rest.pulls.create({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        title: `[${targetBranch}] ${prTitle}`,
+        head: backportBranch,
+        base: targetBranch,
+        body: prBody,
+        draft: hasConflicts
+      });
+      // Add labels
+      await github.rest.issues.addLabels({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: newPR.data.number,
+        labels: ['backport', hasConflicts ? 'needs-manual-resolution' : 'auto-backport']
+      });
+      // Link to original PR
+      await github.rest.issues.createComment({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: prNumber,
+        body: `🤖 Backport PR created for \`${targetBranch}\`: #${newPR.data.number} ${hasConflicts ? '⚠️ (has conflicts)' : '✅'}`
+      });
+      results.push({
+        branch: targetBranch,
+        success: true,
+        prNumber: newPR.data.number,
+        prUrl: newPR.data.html_url,
+        hasConflicts,
+        updated: false
+      });
+      core.info(`✅ Successfully created backport PR #${newPR.data.number}`);
+    }
+  } catch (error) {
+    core.error(`❌ Failed to backport to ${targetBranch}: ${error.message}`);
+    // Comment on original PR about the failure
+    await github.rest.issues.createComment({
+      owner: context.repo.owner,
+      repo: context.repo.repo,
+      issue_number: prNumber,
+      body: `❌ Failed to create backport PR for \`${targetBranch}\`\n\nError: ${error.message}\n\nPlease backport manually.`
+    });
+    results.push({
+      branch: targetBranch,
+      success: false,
+      error: error.message
+    });
+  } finally {
+    // Clean up: go back to main branch
+    try {
+      execSync('git checkout main', { stdio: 'inherit' });
+      execSync(`git branch -D ${backportBranch} 2>/dev/null || true`, { stdio: 'inherit' });
+    } catch (e) {
+      // Ignore cleanup errors
+    }
+  }
+}
+
+// Summary (console only)
+core.info('\n========================================');
+core.info('Backport Summary');
+core.info('========================================');
+for (const result of results) {
+  if (result.success) {
+    const action = result.updated ? 'Updated' : 'Created';
+    core.info(`✅ ${result.branch}: ${action} PR #${result.prNumber} ${result.hasConflicts ? '(has conflicts)' : ''}`);
+  } else {
+    core.error(`❌ ${result.branch}: ${result.error}`);
+  }
+}
+return results;
+};

--- a/.github/scripts/extract-branches.js
+++ b/.github/scripts/extract-branches.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright NVIDIA CORPORATION
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module.exports = async ({ github, context, core }) => {
+  let branches = [];
+
+  // Get PR labels
+  const labels = context.payload.pull_request?.labels || [];
+
+  if (labels.length === 0) {
+    core.info('No labels found on PR - skipping backport');
+    return [];
+  }
+
+  // Extract branches from cherry-pick/* labels
+  const cherryPickPattern = /^cherry-pick\/(release-\d+\.\d+(?:\.\d+)?)$/;
+  
+  for (const label of labels) {
+    const match = label.name.match(cherryPickPattern);
+    if (match) {
+      branches.push(match[1]);
+      core.info(`Found cherry-pick label: ${label.name} -> ${match[1]}`);
+    }
+  }
+
+  if (branches.length === 0) {
+    core.info('No cherry-pick labels found - skipping backport');
+    return [];
+  }
+
+  core.info(`Target branches: ${branches.join(', ')}`);
+  return branches;
+};

--- a/.github/workflows/cherrypick.yml
+++ b/.github/workflows/cherrypick.yml
@@ -1,0 +1,97 @@
+# Copyright NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Cherry-Pick
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  add-labels:
+    name: Add Cherry-Pick Labels from Comment
+    runs-on: ubuntu-latest
+    # Run on /cherry-pick comments on PRs
+    if: |
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request && 
+      startsWith(github.event.comment.body, '/cherry-pick')
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Add labels and handle backport
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const run = require('./.github/scripts/add-labels-from-comment.js');
+            return await run({ github, context, core });
+
+  backport:
+    name: Backport PR
+    runs-on: ubuntu-latest
+    # Run when PR is merged and has cherry-pick labels
+    if: |
+      github.event_name == 'pull_request_target' &&
+      github.event.pull_request.merged == true &&
+      contains(join(github.event.pull_request.labels.*.name, ','), 'cherry-pick/')
+    
+    steps:
+      - name: Checkout base branch repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.base.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract target branches from PR labels
+        id: extract-branches
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const run = require('./.github/scripts/extract-branches.js');
+            return await run({ github, context, core });
+
+      - name: Configure git
+        if: steps.extract-branches.outputs.result != '[]'
+        run: |
+          git config user.name "nvidia-backport-bot"
+          git config user.email "noreply@nvidia.com"
+
+      - name: Backport to release branches
+        id: backport
+        if: steps.extract-branches.outputs.result != '[]'
+        uses: actions/github-script@v8
+        env:
+          BRANCHES_JSON: ${{ steps.extract-branches.outputs.result }}
+        with:
+          script: |
+            const run = require('./.github/scripts/backport.js');
+            return await run({ github, context, core });


### PR DESCRIPTION
Add the cherry-pick GitHub Actions workflow and supporting scripts from
the gpu-operator repo. This enables automated backports to release
branches by commenting `/cherry-pick release-X.Y` on PRs. When a
labeled PR is merged, the workflow cherry-picks the commits to the
target branches and creates backport PRs automatically.

### Testing

Tested in a fork:

Original PR: https://github.com/rajathagasthya/mig-parted/pull/2
Cherry pick PR: https://github.com/rajathagasthya/mig-parted/pull/3