### PR TITLE
Surface service.sh failures in nvidia-mig-manager unit status

### DIFF
--- a/deployments/systemd/nvidia-mig-manager.service
+++ b/deployments/systemd/nvidia-mig-manager.service
@@ -20,7 +20,7 @@ Before=nvidia-gpu-reset.target
 
 [Service]
 Type=oneshot
-ExecStart=-/bin/bash /etc/nvidia-mig-manager/service.sh
+ExecStart=/bin/bash /etc/nvidia-mig-manager/service.sh
 
 [Install]
 WantedBy=multi-user.target nvidia-gpu-reset.target


### PR DESCRIPTION
The ExecStart directive prefixed the command with `-`, which tells
systemd to ignore non-zero exit codes from the script. As a result,
the unit was reported as active (exited) even when service.sh exited
1 on real errors (config generation, mode apply, GPU reset, config
apply), making failures invisible to systemctl status and any
monitoring or automation built on top of it. This contradicts the
script's own explicit exit 1 paths.

Drop the `-` prefix so unit status reflects script status. This is
safe with respect to boot: `WantedBy=multi-user.target` and
`WantedBy=nvidia-gpu-reset.target` both translate to `Wants=` on the
service, which is a weak, non-fatal dependency, so a failed run no
longer blocks either target from activating. The only behavior
change is observability: failures now show up as failed in
systemctl status instead of being silently swallowed.

Resolves #21