### PR TITLE
Replace deprecated reflect.Ptr with reflect.Pointer

### DIFF
--- a/cmd/nvidia-mig-parted/apply/apply.go
+++ b/cmd/nvidia-mig-parted/apply/apply.go
@@ -144,12 +144,12 @@ func GetHooksEnvsMap(c *cli.Context) hooks.EnvsMap {
 	envs := make(hooks.EnvsMap)
 	for _, flag := range c.Command.Flags {
 		fv := reflect.ValueOf(flag)
-		for fv.Kind() == reflect.Ptr {
+		for fv.Kind() == reflect.Pointer {
 			fv = reflect.Indirect(fv)
 		}
 
 		value := fv.FieldByName("Destination")
-		for value.Kind() == reflect.Ptr {
+		for value.Kind() == reflect.Pointer {
 			value = reflect.Indirect(value)
 		}
 


### PR DESCRIPTION
The govet "inline" analyzer in the version of golangci-lint now used
by the Golang CI workflow flags reflect.Ptr as a constant that should
be inlined to its canonical name reflect.Pointer. This was failing the
lint check on the PR even though apply.go was not otherwise touched.

reflect.Ptr is a deprecated alias for reflect.Pointer (since Go 1.18);
the two are the same Kind value, so this is a pure rename.