### PR TITLE
Update GetMigConfig to use GIProfileID from target device

### DIFF
--- a/pkg/mig/config/config.go
+++ b/pkg/mig/config/config.go
@@ -22,6 +22,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
+	nvdevlib "github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 
 	"github.com/NVIDIA/mig-parted/internal/nvlib"
@@ -40,6 +41,20 @@ type nvmlMigConfigManager struct {
 }
 
 var _ Manager = (*nvmlMigConfigManager)(nil)
+
+// resolveMigProfileOnDevice maps a logical MIG profile (from config / Flatten) to the
+// NVML GI/CI profile IDs for the given GPU. Global ParseMigProfile can pick IDs from
+// another GPU when names collide across devices.
+func resolveMigProfileOnDevice(profiles []nvdevlib.MigProfile, mp *types.MigProfile) (*types.MigProfile, error) {
+	key := mp.String()
+	for _, p := range profiles {
+		if p.Matches(key) {
+			info := p.GetInfo()
+			return &types.MigProfile{MigProfileInfo: info}, nil
+		}
+	}
+	return nil, fmt.Errorf("MIG profile %q not found on this GPU", key)
+}
 
 func NewNvmlMigConfigManager(nvml nvml.Interface) Manager {
 	return &nvmlMigConfigManager{nvml, nvlib.NewMock(nvml)}
@@ -98,6 +113,14 @@ func (m *nvmlMigConfigManager) SetMigConfig(gpu int, config types.MigConfig) err
 	if err != nil {
 		return fmt.Errorf("error asserting MIG enabled: %v", err)
 	}
+	nvdev, err := nvdevlib.New(m.nvml).NewDevice(device)
+	if err != nil {
+		return fmt.Errorf("error creating device wrapper: %w", err)
+	}
+	profiles, err := nvdev.GetMigProfiles()
+	if err != nil {
+		return fmt.Errorf("error listing MIG profiles on device: %w", err)
+	}
 
 	err = iteratePermutationsUntilSuccess(config, func(mps []*types.MigProfile) error {
 		clearAttempts := 0
@@ -127,28 +150,33 @@ func (m *nvmlMigConfigManager) SetMigConfig(gpu int, config types.MigConfig) err
 		var lastGIProfileID = -1
 		var gi nvml.GpuInstance = nil
 		for _, mp := range mps {
-			giProfileInfo, ret := device.GetGpuInstanceProfileInfo(mp.GIProfileID)
-			if ret != nvml.SUCCESS {
-				return fmt.Errorf("error getting GPU instance profile info for '%v': %v", mp, ret)
+			resolved, err := resolveMigProfileOnDevice(profiles, mp)
+			if err != nil {
+				return err
 			}
-			reuseGI := (gi != nil) && (lastGIProfileID == mp.GIProfileID)
-			lastGIProfileID = mp.GIProfileID
+
+			giProfileInfo, ret := device.GetGpuInstanceProfileInfo(resolved.GIProfileID)
+			if ret != nvml.SUCCESS {
+				return fmt.Errorf("error getting GPU instance profile info for '%v': %v", resolved, ret)
+			}
+			reuseGI := (gi != nil) && (lastGIProfileID == resolved.GIProfileID)
+			lastGIProfileID = resolved.GIProfileID
 
 			for {
 				if !reuseGI {
 					gi, ret = device.CreateGpuInstance(&giProfileInfo)
 					if ret != nvml.SUCCESS {
-						return fmt.Errorf("error creating GPU instance for '%v': %v", mp, ret)
+						return fmt.Errorf("error creating GPU instance for '%v': %v", resolved, ret)
 					}
 				}
 
-				ciProfileInfo, ret := gi.GetComputeInstanceProfileInfo(mp.CIProfileID, mp.CIEngProfileID)
+				ciProfileInfo, ret := gi.GetComputeInstanceProfileInfo(resolved.CIProfileID, resolved.CIEngProfileID)
 				if ret != nvml.SUCCESS {
 					if reuseGI {
 						reuseGI = false
 						continue
 					}
-					return fmt.Errorf("error getting Compute instance profile info for '%v': %v", mp, ret)
+					return fmt.Errorf("error getting Compute instance profile info for '%v': %v", resolved, ret)
 				}
 
 				_, ret = gi.CreateComputeInstance(&ciProfileInfo)
@@ -157,19 +185,19 @@ func (m *nvmlMigConfigManager) SetMigConfig(gpu int, config types.MigConfig) err
 						reuseGI = false
 						continue
 					}
-					return fmt.Errorf("error creating Compute instance for '%v': %v", mp, ret)
+					return fmt.Errorf("error creating Compute instance for '%v': %v", resolved, ret)
 				}
 
-				valid, err := types.NewMigProfile(mp.GIProfileID, mp.CIProfileID, mp.CIEngProfileID, giProfileInfo.MemorySizeMB, deviceMemory.Total)
+				valid, err := types.NewMigProfile(resolved.GIProfileID, resolved.CIProfileID, resolved.CIEngProfileID, giProfileInfo.MemorySizeMB, deviceMemory.Total)
 				if err != nil {
-					return fmt.Errorf("error creating new MIG profile for %v: %v", mp, err)
+					return fmt.Errorf("error creating new MIG profile for %v: %v", resolved, err)
 				}
-				if !mp.Equals(valid) {
+				if !resolved.Equals(valid) {
 					if reuseGI {
 						reuseGI = false
 						continue
 					}
-					return fmt.Errorf("unsupported MIG Device specified %v, expected %v instead", mp, valid)
+					return fmt.Errorf("unsupported MIG Device specified %v, expected %v instead", resolved, valid)
 				}
 
 				break

--- a/pkg/mig/config/config_test.go
+++ b/pkg/mig/config/config_test.go
@@ -91,6 +91,78 @@ func TestGetSetMigConfig(t *testing.T) {
 	}
 }
 
+// TestSetMigConfigResolvesMigProfileOnTargetGPU models the scenario where the same
+// logical profile (e.g. "1g.10gb") can map to different NVML GIProfileID values on
+// different GPUs. SetMigConfig should resolve the profile specifically for the target
+// GPU, not use globally resolved IDs.
+//
+// For this test, the dgxa100 mock provides two GPUs. GPU 0 uses the default profile
+// table where "1g.10gb" maps to GPU_INSTANCE_PROFILE_1_SLICE_REV2. GPU 1 is overridden
+// so the same profile name maps to GPU_INSTANCE_PROFILE_1_SLICE instead, and REV2 is
+// rejected. Global Flatten() still yields REV2; SetMigConfig on GPU 1 must use SLICE.
+func TestSetMigConfigResolvesMigProfileOnTargetGPU(t *testing.T) {
+	types.SetMockNVdevlib()
+
+	// Mock server with 8 GPUs; we only customize GPU 1 to simulate heterogeneous profile IDs.
+	server := dgxa100.New()
+	manager := &nvmlMigConfigManager{
+		nvml:  server,
+		nvlib: nvlib.NewMock(server),
+	}
+
+	// GPU 0 (unchanged): "1g.10gb" -> GPU_INSTANCE_PROFILE_1_SLICE_REV2 (default mock).
+	// GPU 1 (below):     "1g.10gb" -> GPU_INSTANCE_PROFILE_1_SLICE only.
+	gpu1 := server.Devices[1].(*dgxa100.Device)
+	originalGetGpuInstanceProfileInfo := gpu1.GetGpuInstanceProfileInfoFunc
+	gpu1.GetGpuInstanceProfileInfoFunc = func(giProfileID int) (nvml.GpuInstanceProfileInfo, nvml.Return) {
+		switch giProfileID {
+		case nvml.GPU_INSTANCE_PROFILE_1_SLICE:
+			// GPU 1 accepts the 1-slice profile ID for "1g.10gb".
+			info := dgxa100.MIGProfiles.GpuInstanceProfiles[nvml.GPU_INSTANCE_PROFILE_1_SLICE_REV2]
+			info.Id = nvml.GPU_INSTANCE_PROFILE_1_SLICE
+			return info, nvml.SUCCESS
+		case nvml.GPU_INSTANCE_PROFILE_1_SLICE_REV2:
+			// GPU 1 does not support REV2; using it would reproduce the production error.
+			return nvml.GpuInstanceProfileInfo{}, nvml.ERROR_NOT_SUPPORTED
+		default:
+			return originalGetGpuInstanceProfileInfo(giProfileID)
+		}
+	}
+
+	// Record which GI profile ID SetMigConfig passes to CreateGpuInstance on GPU 1.
+	var createdGIProfileIDs []int
+	originalCreateGpuInstance := gpu1.CreateGpuInstanceFunc
+	gpu1.CreateGpuInstanceFunc = func(info *nvml.GpuInstanceProfileInfo) (nvml.GpuInstance, nvml.Return) {
+		createdGIProfileIDs = append(createdGIProfileIDs, int(info.Id))
+		return originalCreateGpuInstance(info)
+	}
+
+	config := types.MigConfig{"1g.10gb": 1}
+
+	// Flatten uses global ParseMigProfile, which matches GPU 0 first and picks REV2.
+	flattened := config.Flatten()
+	require.Len(t, flattened, 1)
+	require.Equal(t, nvml.GPU_INSTANCE_PROFILE_1_SLICE_REV2, flattened[0].GIProfileID,
+		"Flatten must still use globally resolved IDs (the bug we are guarding against)")
+
+	r1, r2 := EnableMigMode(manager, 1)
+	require.Equal(t, nvml.SUCCESS, r1)
+	require.Equal(t, nvml.SUCCESS, r2)
+
+	// Apply to GPU 1: resolveMigProfileOnDevice should swap REV2 -> SLICE before NVML calls.
+	err := manager.SetMigConfig(1, config)
+	require.NoError(t, err,
+		"SetMigConfig must succeed on GPU 1 despite global Flatten using REV2")
+
+	// Without per-GPU resolution, CreateGpuInstance would be called with REV2 and fail.
+	require.Equal(t, []int{nvml.GPU_INSTANCE_PROFILE_1_SLICE}, createdGIProfileIDs,
+		"GPU 1 must be configured with its own GI profile ID, not the globally resolved one")
+
+	actual, err := manager.GetMigConfig(1)
+	require.NoError(t, err, "Unexpected failure from GetMigConfig")
+	require.Equal(t, config, actual)
+}
+
 func TestClearMigConfig(t *testing.T) {
 	types.SetMockNVdevlib()
 	mcg := NewA100_SXM4_40GB_MigConfigGroup()


### PR DESCRIPTION
This MR is in response to this issue: https://github.com/NVIDIA/mig-parted/issues/157?reload=1?reload=1. Essentially the issue we are seeing is that SetMigConfig(gpu, config) resolves MIG profile strings (e.g. "1g.6gb") to GIProfileID values globally across all GPUs, not from the target device. As such, if the GIProfileID of a partition in GPU 0 differs from the GIProfileID of a partition in GPU 1, the mig manager will error: Error getting GPU instance profile info for '1g.6gb': ERROR_NOT_SUPPORTED"

To fix this, a helper function resolveMigProfileOnDevice was created that will map a logical MIG profile (from config / Flatten) to the NVML GI/CI profile IDs for the given GPU. It will loop through the profiles in GetMigProfiles() and identify the profile that matches the mp.String() we are trying to create. We will then update with the correct profile info.

In order to test this change, func TestSetMigConfigResolvesMigProfileOnTargetGPU was defined. The function will create two dummy GPUs, and override the GI Profile ID for GPU 1.

local-agadiyar@ipp2-0139:~/mig-parted$ go test ./pkg/mig/config -run TestSetMigConfigResolvesMigProfileOnTargetGPU -count=1
ok      github.com/NVIDIA/mig-parted/pkg/mig/config     0.008s

