### PR TITLE
fix: persist MIG_PARTED_CONFIG_FILE and MIG_PARTED_HOOKS_FILE across reboots

### DIFF
--- a/deployments/systemd/utils.sh
+++ b/deployments/systemd/utils.sh
@@ -75,10 +75,16 @@ function nvidia-mig-manager::service::clear_reboot_state() {
 
 function nvidia-mig-manager::service::persist_config_across_reboot() {
 	local selected_config="${1}"
-cat << EOF > /etc/systemd/system/nvidia-mig-manager.service.d/override.conf
-[Service]
-Environment="MIG_PARTED_SELECTED_CONFIG=${selected_config}"
-EOF
+	{
+		echo "[Service]"
+		if [ -n "${MIG_PARTED_CONFIG_FILE}" ]; then
+			echo "Environment=\"MIG_PARTED_CONFIG_FILE=${MIG_PARTED_CONFIG_FILE}\""
+		fi
+		if [ -n "${MIG_PARTED_HOOKS_FILE}" ]; then
+			echo "Environment=\"MIG_PARTED_HOOKS_FILE=${MIG_PARTED_HOOKS_FILE}\""
+		fi
+		echo "Environment=\"MIG_PARTED_SELECTED_CONFIG=${selected_config}\""
+	} > /etc/systemd/system/nvidia-mig-manager.service.d/override.conf
 	systemctl daemon-reload
 }
 


### PR DESCRIPTION
## Summary

- **Fixes core bug in `persist_config_across_reboot()`:** Corrected behavior in `deployments/systemd/utils.sh` where the function exclusively wrote `MIG_PARTED_SELECTED_CONFIG` to `override.conf`, silently stripping `MIG_PARTED_CONFIG_FILE` and `MIG_PARTED_HOOKS_FILE` during execution.
- **Restores custom configuration feature:** This regression directly broke the documented custom configuration mechanism. While `service.sh` explicitly notes `# To use a custom config, set MIG_PARTED_CONFIG_FILE`, the utility hook destroyed this state before the subsequent reboot, triggering a terminal `Error selecting MIG config: selected mig-config not present` error during boot phase.
- **Preserves user-defined variables safely:** The logic now conditionally appends `MIG_PARTED_CONFIG_FILE` and `MIG_PARTED_HOOKS_FILE` to `override.conf` only when they are explicitly set. This ensures custom user-supplied configs persist across host restarts while introducing zero changes or regressions when running on default settings.

## Path to Reproduction

1. Declare a custom configuration path by defining `MIG_PARTED_CONFIG_FILE` within `override.conf`.
2. Execute/Start `nvidia-mig-manager.service` — notice the configuration applies successfully on initialization.
3. Inspect `override.conf` immediately after launch — observe that `MIG_PARTED_CONFIG_FILE` has been cleared out.
4. Reboot the host system — the service will fail with: 
   `Error selecting MIG config: selected mig-config not present`

## Test Plan

- [ ] **Verify Variable Retention:** Initialize the service with `MIG_PARTED_CONFIG_FILE` configured. Confirm that `override.conf` retains both variables post-execution.
- [ ] **Regression & Default Check:** Initialize the service *without* defining `MIG_PARTED_CONFIG_FILE`. Confirm that `override.conf` strictly populates `MIG_PARTED_SELECTED_CONFIG` to match legacy expectations.
- [ ] **End-to-End Reboot Test:** Assign a custom configuration, cycle host power, and confirm that the custom MIG profile builds and binds seamlessly upon system reboot.