### PR TITLE
Support Read-Only, systemd-less Systems

### DIFF
--- a/cmd/nvidia-mig-manager/main.go
+++ b/cmd/nvidia-mig-manager/main.go
@@ -58,6 +58,7 @@ const (
 	DefaultDriverRootCtrPath         = "/run/nvidia/driver"
 	DefaultNvidiaCDIHookPath         = "/usr/local/nvidia/toolkit/nvidia-cdi-hook"
 	DefaultGeneratedConfigFile       = "/etc/nvidia-mig-manager/generated-config.yaml"
+	DefaultSystemdTimeout            = 1.0
 )
 
 var (
@@ -80,6 +81,7 @@ var (
 	devRoot           string
 	devRootCtrPath    string
 	nvidiaCDIHookPath string
+	systemdTimeout    float64
 )
 
 type GPUClients struct {
@@ -265,6 +267,13 @@ func main() {
 			Usage:       "Path to nvidia-cdi-hook binary on the host.",
 			Destination: &nvidiaCDIHookPath,
 			Sources:     cli.EnvVars("NVIDIA_CDI_HOOK_PATH"),
+		},
+		&cli.Float64Flag{
+			Name:        "systemd-timeout",
+			Value:       DefaultSystemdTimeout,
+			Usage:       "Timeout for systemd connection (in seconds)",
+			Destination: &systemdTimeout,
+			Sources:     cli.EnvVars("SYSTEMD_CONNECTION_TIMEOUT"),
 		},
 	}
 
@@ -522,6 +531,7 @@ func migReconfigure(ctx context.Context, migConfigValue string, clientset *kuber
 		DefaultGPUClientsNamespace: defaultGPUClientsNamespaceFlag,
 		WithReboot:                 withRebootFlag,
 		WithShutdownHostGPUClients: withShutdownHostGPUClientsFlag,
+		SystemdTimeout:             systemdTimeout,
 	}
 
 	if cdiEnabledFlag {

--- a/cmd/nvidia-mig-manager/main.go
+++ b/cmd/nvidia-mig-manager/main.go
@@ -81,7 +81,6 @@ var (
 	devRoot           string
 	devRootCtrPath    string
 	nvidiaCDIHookPath string
-	systemdTimeout    float64
 )
 
 type GPUClients struct {
@@ -267,13 +266,6 @@ func main() {
 			Usage:       "Path to nvidia-cdi-hook binary on the host.",
 			Destination: &nvidiaCDIHookPath,
 			Sources:     cli.EnvVars("NVIDIA_CDI_HOOK_PATH"),
-		},
-		&cli.Float64Flag{
-			Name:        "systemd-timeout",
-			Value:       DefaultSystemdTimeout,
-			Usage:       "Timeout for systemd connection (in seconds)",
-			Destination: &systemdTimeout,
-			Sources:     cli.EnvVars("SYSTEMD_CONNECTION_TIMEOUT"),
 		},
 	}
 
@@ -531,7 +523,6 @@ func migReconfigure(ctx context.Context, migConfigValue string, clientset *kuber
 		DefaultGPUClientsNamespace: defaultGPUClientsNamespaceFlag,
 		WithReboot:                 withRebootFlag,
 		WithShutdownHostGPUClients: withShutdownHostGPUClientsFlag,
-		SystemdTimeout:             systemdTimeout,
 	}
 
 	if cdiEnabledFlag {

--- a/cmd/nvidia-mig-manager/main.go
+++ b/cmd/nvidia-mig-manager/main.go
@@ -58,7 +58,6 @@ const (
 	DefaultDriverRootCtrPath         = "/run/nvidia/driver"
 	DefaultNvidiaCDIHookPath         = "/usr/local/nvidia/toolkit/nvidia-cdi-hook"
 	DefaultGeneratedConfigFile       = "/etc/nvidia-mig-manager/generated-config.yaml"
-	DefaultSystemdTimeout            = 1.0
 )
 
 var (

--- a/internal/systemd/systemd.go
+++ b/internal/systemd/systemd.go
@@ -35,10 +35,22 @@ type Manager struct {
 }
 
 // NewManager creates a new Manager instance
-func NewManager(ctx context.Context) (*Manager, error) {
-	conn, err := dbus.NewSystemConnectionContext(ctx)
+func NewManager(ctx context.Context, timeout time.Duration) (*Manager, error) {
+	deadline, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	conn, err := dbus.NewSystemConnectionContext(deadline)
 	if err != nil {
-		return nil, fmt.Errorf("failed to connect to systemd D-Bus: %w", err)
+		err = fmt.Errorf("failed to connect to systemd D-Bus: %w", err)
+		if timeout := deadline.Err(); timeout == context.DeadlineExceeded {
+			err = errors.Join(err, timeout)
+		}
+		return nil, err
+	}
+
+	conn, err = dbus.NewSystemConnectionContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to recreate connection with no timeout")
 	}
 
 	return &Manager{

--- a/internal/systemd/systemd.go
+++ b/internal/systemd/systemd.go
@@ -34,9 +34,11 @@ type Manager struct {
 	conn *dbus.Conn
 }
 
+const SystemdTimeout = 2 * time.Second
+
 // NewManager creates a new Manager instance
-func NewManager(ctx context.Context, timeout time.Duration) (*Manager, error) {
-	deadline, cancel := context.WithTimeout(ctx, timeout)
+func NewManager(ctx context.Context) (*Manager, error) {
+	deadline, cancel := context.WithTimeout(ctx, SystemdTimeout)
 	defer cancel()
 
 	conn, err := dbus.NewSystemConnectionContext(deadline)
@@ -50,7 +52,7 @@ func NewManager(ctx context.Context, timeout time.Duration) (*Manager, error) {
 
 	conn, err = dbus.NewSystemConnectionContext(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to recreate connection with no timeout")
+		return nil, fmt.Errorf("failed to recreate connection with no timeout: %w", err)
 	}
 
 	return &Manager{

--- a/internal/systemd/systemd.go
+++ b/internal/systemd/systemd.go
@@ -27,44 +27,85 @@ import (
 	"github.com/coreos/go-systemd/v22/dbus"
 )
 
+// systemdConnectTimeout bounds how long NewManager waits for the systemd D-Bus
+// connection (dial plus auth handshake) to be established. On hosts without a
+// running systemd/D-Bus daemon the system bus socket may still exist - for
+// example when /run/dbus/system_bus_socket is bind-mounted from the host - but
+// never answer, in which case the underlying auth handshake would otherwise
+// block forever. Bounding it turns that indefinite hang into a fast, actionable
+// error.
+const systemdConnectTimeout = 10 * time.Second
+
 // Manager handles systemd operations using the D-Bus API
 type Manager struct {
 	ctx context.Context
 
-	conn *dbus.Conn
+	conn   *dbus.Conn
+	cancel context.CancelFunc
 }
 
-const SystemdTimeout = 2 * time.Second
-
-// NewManager creates a new Manager instance
+// NewManager creates a new Manager instance connected to the systemd system
+// bus. It fails fast, rather than blocking indefinitely, when the D-Bus socket
+// exists but no systemd daemon is answering (as happens on systemd-less hosts
+// such as Talos Linux).
 func NewManager(ctx context.Context) (*Manager, error) {
-	deadline, cancel := context.WithTimeout(ctx, SystemdTimeout)
-	defer cancel()
+	return newManagerWithTimeout(ctx, systemdConnectTimeout)
+}
 
-	conn, err := dbus.NewSystemConnectionContext(deadline)
-	if err != nil {
-		err = fmt.Errorf("failed to connect to systemd D-Bus: %w", err)
-		if timeout := deadline.Err(); timeout == context.DeadlineExceeded {
-			err = errors.Join(err, timeout)
+// newManagerWithTimeout is the testable core of NewManager, with the connection
+// timeout injected so tests do not have to wait for the production default.
+func newManagerWithTimeout(ctx context.Context, timeout time.Duration) (*Manager, error) {
+	// Derive a cancelable context for the connection. go-systemd/godbus tie the
+	// lifetime of the connection to this context and, crucially, spawn a watcher
+	// goroutine that closes the underlying socket as soon as the context is done.
+	// We rely on that to unblock a stuck auth handshake: if the dial does not
+	// complete within the timeout we cancel the context, the socket is closed,
+	// and the blocked read returns an error instead of hanging forever.
+	connCtx, cancel := context.WithCancel(ctx)
+
+	type result struct {
+		conn *dbus.Conn
+		err  error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		conn, err := dbus.NewSystemConnectionContext(connCtx)
+		ch <- result{conn: conn, err: err}
+	}()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case res := <-ch:
+		if res.err != nil {
+			cancel()
+			return nil, fmt.Errorf("failed to connect to systemd D-Bus: %w", res.err)
 		}
-		return nil, err
+		// Success: the connection (and connCtx) must outlive this call, so we do
+		// not cancel here. cancel is retained and invoked by Close().
+		return &Manager{
+			ctx:    ctx,
+			conn:   res.conn,
+			cancel: cancel,
+		}, nil
+	case <-timer.C:
+		// The dial is stuck: the socket exists but nothing is answering, as on a
+		// systemd-less host. Cancel the connection context so the godbus watcher
+		// closes the socket and unblocks the goroutine above, then report a clear
+		// error instead of hanging.
+		cancel()
+		return nil, fmt.Errorf("timed out after %s connecting to systemd D-Bus: the system bus socket exists but is not responding (is this a systemd-less host?)", timeout)
 	}
-
-	conn, err = dbus.NewSystemConnectionContext(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to recreate connection with no timeout: %w", err)
-	}
-
-	return &Manager{
-		ctx:  ctx,
-		conn: conn,
-	}, nil
 }
 
 // Close closes the D-Bus connection
 func (sm *Manager) Close() error {
 	if sm.conn != nil {
 		sm.conn.Close()
+	}
+	if sm.cancel != nil {
+		sm.cancel()
 	}
 	return nil
 }

--- a/internal/systemd/systemd.go
+++ b/internal/systemd/systemd.go
@@ -27,13 +27,8 @@ import (
 	"github.com/coreos/go-systemd/v22/dbus"
 )
 
-// systemdConnectTimeout bounds how long NewManager waits for the systemd D-Bus
-// connection (dial plus auth handshake) to be established. On hosts without a
-// running systemd/D-Bus daemon the system bus socket may still exist - for
-// example when /run/dbus/system_bus_socket is bind-mounted from the host - but
-// never answer, in which case the underlying auth handshake would otherwise
-// block forever. Bounding it turns that indefinite hang into a fast, actionable
-// error.
+// systemdConnectTimeout limits how long NewManager waits for the systemd D-Bus
+// connection (dial plus auth handshake) to be established
 const systemdConnectTimeout = 10 * time.Second
 
 // Manager handles systemd operations using the D-Bus API
@@ -44,23 +39,11 @@ type Manager struct {
 	cancel context.CancelFunc
 }
 
-// NewManager creates a new Manager instance connected to the systemd system
-// bus. It fails fast, rather than blocking indefinitely, when the D-Bus socket
-// exists but no systemd daemon is answering (as happens on systemd-less hosts
-// such as Talos Linux).
 func NewManager(ctx context.Context) (*Manager, error) {
 	return newManagerWithTimeout(ctx, systemdConnectTimeout)
 }
 
-// newManagerWithTimeout is the testable core of NewManager, with the connection
-// timeout injected so tests do not have to wait for the production default.
 func newManagerWithTimeout(ctx context.Context, timeout time.Duration) (*Manager, error) {
-	// Derive a cancelable context for the connection. go-systemd/godbus tie the
-	// lifetime of the connection to this context and, crucially, spawn a watcher
-	// goroutine that closes the underlying socket as soon as the context is done.
-	// We rely on that to unblock a stuck auth handshake: if the dial does not
-	// complete within the timeout we cancel the context, the socket is closed,
-	// and the blocked read returns an error instead of hanging forever.
 	connCtx, cancel := context.WithCancel(ctx)
 
 	type result struct {
@@ -82,18 +65,12 @@ func newManagerWithTimeout(ctx context.Context, timeout time.Duration) (*Manager
 			cancel()
 			return nil, fmt.Errorf("failed to connect to systemd D-Bus: %w", res.err)
 		}
-		// Success: the connection (and connCtx) must outlive this call, so we do
-		// not cancel here. cancel is retained and invoked by Close().
 		return &Manager{
 			ctx:    ctx,
 			conn:   res.conn,
 			cancel: cancel,
 		}, nil
 	case <-timer.C:
-		// The dial is stuck: the socket exists but nothing is answering, as on a
-		// systemd-less host. Cancel the connection context so the godbus watcher
-		// closes the socket and unblocks the goroutine above, then report a clear
-		// error instead of hanging.
 		cancel()
 		return nil, fmt.Errorf("timed out after %s connecting to systemd D-Bus: the system bus socket exists but is not responding (is this a systemd-less host?)", timeout)
 	}

--- a/internal/systemd/systemd.go
+++ b/internal/systemd/systemd.go
@@ -39,22 +39,30 @@ type Manager struct {
 	cancel context.CancelFunc
 }
 
-func NewManager(ctx context.Context) (*Manager, error) {
-	return newManagerWithTimeout(ctx, systemdConnectTimeout)
+type result struct {
+	conn *dbus.Conn
+	err  error
 }
 
-func newManagerWithTimeout(ctx context.Context, timeout time.Duration) (*Manager, error) {
-	connCtx, cancel := context.WithCancel(ctx)
+// NewManager creates a new Manager instance with a timeout on the systemd connection
+func NewManager(ctx context.Context) (*Manager, error) {
+	return newManagerWithTimeout(ctx, systemdConnectTimeout, nil)
+}
 
-	type result struct {
-		conn *dbus.Conn
-		err  error
-	}
+func defaultConnect(connCtx context.Context, ch chan result) {
+	conn, err := dbus.NewSystemConnectionContext(connCtx)
+	ch <- result{conn: conn, err: err}
+}
+
+func newManagerWithTimeout(ctx context.Context, timeout time.Duration, connect func(context.Context, chan result)) (*Manager, error) {
+	connCtx, cancel := context.WithCancel(ctx)
 	ch := make(chan result, 1)
-	go func() {
-		conn, err := dbus.NewSystemConnectionContext(connCtx)
-		ch <- result{conn: conn, err: err}
-	}()
+
+	if connect == nil {
+		connect = defaultConnect
+	}
+
+	go connect(connCtx, ch)
 
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()
@@ -72,6 +80,12 @@ func newManagerWithTimeout(ctx context.Context, timeout time.Duration) (*Manager
 		}, nil
 	case <-timer.C:
 		cancel()
+		select {
+		case res := <-ch:
+			if res.conn != nil {
+				res.conn.Close()
+			}
+		}
 		return nil, fmt.Errorf("timed out after %s connecting to systemd D-Bus: the system bus socket exists but is not responding (is this a systemd-less host?)", timeout)
 	}
 }

--- a/internal/systemd/systemd.go
+++ b/internal/systemd/systemd.go
@@ -80,12 +80,14 @@ func newManagerWithTimeout(ctx context.Context, timeout time.Duration, connect f
 		}, nil
 	case <-timer.C:
 		cancel()
-		select {
-		case res := <-ch:
+
+		go func() {
+			res := <-ch
 			if res.conn != nil {
 				res.conn.Close()
 			}
-		}
+		}()
+
 		return nil, fmt.Errorf("timed out after %s connecting to systemd D-Bus: the system bus socket exists but is not responding (is this a systemd-less host?)", timeout)
 	}
 }

--- a/internal/systemd/systemd.go
+++ b/internal/systemd/systemd.go
@@ -65,7 +65,7 @@ func newManagerWithTimeout(ctx context.Context, timeout time.Duration, connect f
 		case ch <- res:
 			// Connected within time limit
 		case <-connCtx.Done():
-			// Drain connection if obtained after timeout
+			// Explicitly drain connection if obtained after timeout
 			if conn != nil {
 				conn.Close()
 			}
@@ -87,6 +87,7 @@ func newManagerWithTimeout(ctx context.Context, timeout time.Duration, connect f
 			cancel: cancel,
 		}, nil
 	case <-timer.C:
+		// Canceling the connection context both disconnects a late result and aborts an ongoing connection attempt
 		cancel()
 		return nil, fmt.Errorf("timed out after %s connecting to systemd D-Bus: the system bus socket exists but is not responding (is this a systemd-less host?)", timeout)
 	}

--- a/internal/systemd/systemd.go
+++ b/internal/systemd/systemd.go
@@ -49,20 +49,28 @@ func NewManager(ctx context.Context) (*Manager, error) {
 	return newManagerWithTimeout(ctx, systemdConnectTimeout, nil)
 }
 
-func defaultConnect(connCtx context.Context, ch chan result) {
-	conn, err := dbus.NewSystemConnectionContext(connCtx)
-	ch <- result{conn: conn, err: err}
-}
-
-func newManagerWithTimeout(ctx context.Context, timeout time.Duration, connect func(context.Context, chan result)) (*Manager, error) {
+func newManagerWithTimeout(ctx context.Context, timeout time.Duration, connect func(context.Context) (*dbus.Conn, error)) (*Manager, error) {
 	connCtx, cancel := context.WithCancel(ctx)
 	ch := make(chan result, 1)
 
 	if connect == nil {
-		connect = defaultConnect
+		connect = dbus.NewSystemConnectionContext
 	}
 
-	go connect(connCtx, ch)
+	go func() {
+		// Block until connected or canceled
+		conn, err := connect(connCtx)
+		res := result{conn: conn, err: err}
+		select {
+		case ch <- res:
+			// Connected within time limit
+		case <-connCtx.Done():
+			// Drain connection if obtained after timeout
+			if conn != nil {
+				conn.Close()
+			}
+		}
+	}()
 
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()
@@ -80,14 +88,6 @@ func newManagerWithTimeout(ctx context.Context, timeout time.Duration, connect f
 		}, nil
 	case <-timer.C:
 		cancel()
-
-		go func() {
-			res := <-ch
-			if res.conn != nil {
-				res.conn.Close()
-			}
-		}()
-
 		return nil, fmt.Errorf("timed out after %s connecting to systemd D-Bus: the system bus socket exists but is not responding (is this a systemd-less host?)", timeout)
 	}
 }

--- a/internal/systemd/systemd_test.go
+++ b/internal/systemd/systemd_test.go
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package systemd
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// setBusAddress points the D-Bus client library at socketPath for the duration
+// of the test. godbus resolves the system bus address from different
+// environment variables depending on the platform (DBUS_SYSTEM_BUS_ADDRESS on
+// Linux, DBUS_LAUNCHD_SESSION_BUS_SOCKET on macOS), so we set both to keep the
+// test portable between the CI runners and local development machines.
+func setBusAddress(t *testing.T, socketPath string) {
+	t.Helper()
+	t.Setenv("DBUS_SYSTEM_BUS_ADDRESS", "unix:path="+socketPath)
+	t.Setenv("DBUS_LAUNCHD_SESSION_BUS_SOCKET", socketPath)
+}
+
+// shortSocketPath returns a socket path in a fresh temp dir kept short enough to
+// stay under the ~104 byte sun_path limit for unix domain sockets (t.TempDir()
+// embeds the test name and can overflow that limit on macOS).
+func shortSocketPath(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "migp")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return filepath.Join(dir, "s")
+}
+
+// TestNewManagerWithTimeoutUnresponsiveSocket reproduces the systemd-less-host
+// failure mode: a system bus socket that exists (something is listening) but
+// never answers the D-Bus auth handshake. Before the fix this blocked forever;
+// NewManager must instead fail fast once the connect timeout elapses.
+func TestNewManagerWithTimeoutUnresponsiveSocket(t *testing.T) {
+	socketPath := shortSocketPath(t)
+
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("failed to listen on unix socket %q: %v", socketPath, err)
+	}
+	defer listener.Close()
+
+	// Accept connections but never write a reply, mimicking a bind-mounted host
+	// socket with no systemd/D-Bus daemon behind it.
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			// Hold the connection open without responding.
+			t.Cleanup(func() { _ = conn.Close() })
+		}
+	}()
+
+	setBusAddress(t, socketPath)
+
+	const timeout = 300 * time.Millisecond
+	start := time.Now()
+	mgr, err := newManagerWithTimeout(context.Background(), timeout)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		_ = mgr.Close()
+		t.Fatal("expected an error connecting to an unresponsive D-Bus socket, got nil")
+	}
+	if mgr != nil {
+		t.Errorf("expected a nil manager on error, got %v", mgr)
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Errorf("expected a timeout error, got: %v", err)
+	}
+	// The call must return promptly after the timeout, not hang. A generous
+	// upper bound still catches a regression back to the indefinite block.
+	if elapsed > 5*time.Second {
+		t.Errorf("connect took %s, expected it to fail fast near the %s timeout", elapsed, timeout)
+	}
+}
+
+// TestNewManagerWithTimeoutMissingSocket verifies that a missing socket fails
+// immediately via the dial error path, well before the connect timeout - i.e.
+// the timeout is a backstop, not the primary error path.
+func TestNewManagerWithTimeoutMissingSocket(t *testing.T) {
+	// A path that does not exist: the dial fails right away.
+	setBusAddress(t, filepath.Join(t.TempDir(), "does-not-exist"))
+
+	const timeout = 10 * time.Second
+	start := time.Now()
+	mgr, err := newManagerWithTimeout(context.Background(), timeout)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		_ = mgr.Close()
+		t.Fatal("expected an error connecting to a missing D-Bus socket, got nil")
+	}
+	if mgr != nil {
+		t.Errorf("expected a nil manager on error, got %v", mgr)
+	}
+	if strings.Contains(err.Error(), "timed out") {
+		t.Errorf("expected the immediate dial error, not the timeout error: %v", err)
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("connect to a missing socket took %s, expected it to fail immediately", elapsed)
+	}
+}
+
+// TestManagerCloseNil ensures Close is safe on a zero-value Manager (no
+// connection, no cancel func), matching how cleanup paths may call it.
+func TestManagerCloseNil(t *testing.T) {
+	var mgr Manager
+	if err := mgr.Close(); err != nil {
+		t.Errorf("Close on a zero-value Manager returned an error: %v", err)
+	}
+}

--- a/internal/systemd/systemd_test.go
+++ b/internal/systemd/systemd_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,20 +26,12 @@ import (
 	"time"
 )
 
-// setBusAddress points the D-Bus client library at socketPath for the duration
-// of the test. godbus resolves the system bus address from different
-// environment variables depending on the platform (DBUS_SYSTEM_BUS_ADDRESS on
-// Linux, DBUS_LAUNCHD_SESSION_BUS_SOCKET on macOS), so we set both to keep the
-// test portable between the CI runners and local development machines.
 func setBusAddress(t *testing.T, socketPath string) {
 	t.Helper()
 	t.Setenv("DBUS_SYSTEM_BUS_ADDRESS", "unix:path="+socketPath)
 	t.Setenv("DBUS_LAUNCHD_SESSION_BUS_SOCKET", socketPath)
 }
 
-// shortSocketPath returns a socket path in a fresh temp dir kept short enough to
-// stay under the ~104 byte sun_path limit for unix domain sockets (t.TempDir()
-// embeds the test name and can overflow that limit on macOS).
 func shortSocketPath(t *testing.T) string {
 	t.Helper()
 	dir, err := os.MkdirTemp("", "migp")
@@ -50,10 +42,6 @@ func shortSocketPath(t *testing.T) string {
 	return filepath.Join(dir, "s")
 }
 
-// TestNewManagerWithTimeoutUnresponsiveSocket reproduces the systemd-less-host
-// failure mode: a system bus socket that exists (something is listening) but
-// never answers the D-Bus auth handshake. Before the fix this blocked forever;
-// NewManager must instead fail fast once the connect timeout elapses.
 func TestNewManagerWithTimeoutUnresponsiveSocket(t *testing.T) {
 	socketPath := shortSocketPath(t)
 
@@ -100,11 +88,7 @@ func TestNewManagerWithTimeoutUnresponsiveSocket(t *testing.T) {
 	}
 }
 
-// TestNewManagerWithTimeoutMissingSocket verifies that a missing socket fails
-// immediately via the dial error path, well before the connect timeout - i.e.
-// the timeout is a backstop, not the primary error path.
 func TestNewManagerWithTimeoutMissingSocket(t *testing.T) {
-	// A path that does not exist: the dial fails right away.
 	setBusAddress(t, filepath.Join(t.TempDir(), "does-not-exist"))
 
 	const timeout = 10 * time.Second
@@ -127,8 +111,6 @@ func TestNewManagerWithTimeoutMissingSocket(t *testing.T) {
 	}
 }
 
-// TestManagerCloseNil ensures Close is safe on a zero-value Manager (no
-// connection, no cancel func), matching how cleanup paths may call it.
 func TestManagerCloseNil(t *testing.T) {
 	var mgr Manager
 	if err := mgr.Close(); err != nil {

--- a/internal/systemd/systemd_test.go
+++ b/internal/systemd/systemd_test.go
@@ -137,9 +137,7 @@ func TestManagerRace(t *testing.T) {
 		conn, err = dbus.NewSystemConnectionContext(ctx)
 
 		// Only send result after context is canceled to simulate race condition
-		select {
-		case <-ctx.Done():
-		}
+		<-ctx.Done()
 
 		return conn, err
 	}
@@ -150,5 +148,24 @@ func TestManagerRace(t *testing.T) {
 
 	if conn.Connected() {
 		t.Errorf("expected connection to be dropped after timeout")
+	}
+}
+
+func TestCancelDbus(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	conn, err := dbus.NewSystemConnectionContext(ctx)
+	if err != nil {
+		t.Errorf("expected successful connection, got error: %v", err)
+	}
+
+	if !conn.Connected() {
+		t.Error("connection is not connected")
+	}
+
+	cancel()
+
+	if conn.Connected() {
+		t.Error("canceling connection context did not disconnect dbus")
 	}
 }

--- a/internal/systemd/systemd_test.go
+++ b/internal/systemd/systemd_test.go
@@ -24,6 +24,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/coreos/go-systemd/v22/dbus"
 )
 
 func setBusAddress(t *testing.T, socketPath string) {
@@ -40,6 +42,19 @@ func shortSocketPath(t *testing.T) string {
 	}
 	t.Cleanup(func() { _ = os.RemoveAll(dir) })
 	return filepath.Join(dir, "s")
+}
+
+func expectTimeout(t *testing.T, mgr *Manager, err error) {
+	if err == nil {
+		_ = mgr.Close()
+		t.Fatal("expected an error connecting to an unresponsive D-Bus socket, got nil")
+	}
+	if mgr != nil {
+		t.Errorf("expected a nil manager on error, got %v", mgr)
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Errorf("expected a timeout error, got: %v", err)
+	}
 }
 
 func TestNewManagerWithTimeoutUnresponsiveSocket(t *testing.T) {
@@ -68,19 +83,11 @@ func TestNewManagerWithTimeoutUnresponsiveSocket(t *testing.T) {
 
 	const timeout = 300 * time.Millisecond
 	start := time.Now()
-	mgr, err := newManagerWithTimeout(context.Background(), timeout)
+	mgr, err := newManagerWithTimeout(context.Background(), timeout, nil)
 	elapsed := time.Since(start)
 
-	if err == nil {
-		_ = mgr.Close()
-		t.Fatal("expected an error connecting to an unresponsive D-Bus socket, got nil")
-	}
-	if mgr != nil {
-		t.Errorf("expected a nil manager on error, got %v", mgr)
-	}
-	if !strings.Contains(err.Error(), "timed out") {
-		t.Errorf("expected a timeout error, got: %v", err)
-	}
+	expectTimeout(t, mgr, err)
+
 	// The call must return promptly after the timeout, not hang. A generous
 	// upper bound still catches a regression back to the indefinite block.
 	if elapsed > 5*time.Second {
@@ -93,7 +100,7 @@ func TestNewManagerWithTimeoutMissingSocket(t *testing.T) {
 
 	const timeout = 10 * time.Second
 	start := time.Now()
-	mgr, err := newManagerWithTimeout(context.Background(), timeout)
+	mgr, err := newManagerWithTimeout(context.Background(), timeout, nil)
 	elapsed := time.Since(start)
 
 	if err == nil {
@@ -115,5 +122,35 @@ func TestManagerCloseNil(t *testing.T) {
 	var mgr Manager
 	if err := mgr.Close(); err != nil {
 		t.Errorf("Close on a zero-value Manager returned an error: %v", err)
+	}
+}
+
+func TestManagerRace(t *testing.T) {
+	const timeout = 1 * time.Second
+
+	var conn *dbus.Conn
+
+	delayedConnect := func(ctx context.Context, ch chan result) {
+		// Intercept the connection so we can check its state afterwards
+		intercept := make(chan result, 1)
+		defaultConnect(ctx, intercept)
+		res := <-intercept
+		conn = res.conn
+
+		// Only send result after context is canceled to simulate race condition
+		select {
+		case <-ctx.Done():
+			if ctx.Err() == context.Canceled {
+				ch <- res
+			}
+		}
+	}
+
+	mgr, err := newManagerWithTimeout(context.Background(), timeout, delayedConnect)
+
+	expectTimeout(t, mgr, err)
+
+	if conn.Connected() {
+		t.Errorf("expected connection to be dropped after timeout")
 	}
 }

--- a/internal/systemd/systemd_test.go
+++ b/internal/systemd/systemd_test.go
@@ -130,20 +130,18 @@ func TestManagerRace(t *testing.T) {
 
 	var conn *dbus.Conn
 
-	delayedConnect := func(ctx context.Context, ch chan result) {
+	delayedConnect := func(ctx context.Context) (*dbus.Conn, error) {
+		var err error
+
 		// Intercept the connection so we can check its state afterwards
-		intercept := make(chan result, 1)
-		defaultConnect(ctx, intercept)
-		res := <-intercept
-		conn = res.conn
+		conn, err = dbus.NewSystemConnectionContext(ctx)
 
 		// Only send result after context is canceled to simulate race condition
 		select {
 		case <-ctx.Done():
-			if ctx.Err() == context.Canceled {
-				ch <- res
-			}
 		}
+
+		return conn, err
 	}
 
 	mgr, err := newManagerWithTimeout(context.Background(), timeout, delayedConnect)

--- a/pkg/mig/reconfigure/reconfigure.go
+++ b/pkg/mig/reconfigure/reconfigure.go
@@ -98,13 +98,14 @@ type Reconfigure struct {
 	stoppedServices       []string
 }
 
-// New creates a new Reconfigure instance
+// New creates a new Reconfigure instance.
+//
+// The connection to the host's systemd D-Bus is established lazily (see
+// systemdMgr), not here. Constructing a Reconfigure never dials D-Bus, so a
+// reconfiguration that does not touch host systemd - the common case, and the
+// only workable case on systemd-less hosts such as Talos Linux - never blocks
+// on an unresponsive system bus socket.
 func New(ctx context.Context, clientset *kubernetes.Clientset, migPartedBinary []string, opts *Options) (*Reconfigure, error) {
-	if len(opts.HostRootMount) > 0 {
-		hostSystemBusAddress := fmt.Sprintf("unix:path=%s/run/dbus/system_bus_socket", opts.HostRootMount)
-		_ = os.Setenv("DBUS_SYSTEM_BUS_ADDRESS", hostSystemBusAddress)
-	}
-
 	return &Reconfigure{
 		ctx:             ctx,
 		clientset:       clientset,
@@ -113,9 +114,22 @@ func New(ctx context.Context, clientset *kubernetes.Clientset, migPartedBinary [
 	}, nil
 }
 
+// getSystemdManager lazily establishes and caches the connection to the host's systemd
+// D-Bus. It is only ever called from code paths that genuinely need systemd:
+// persisting the host mig-manager state file (which triggers a daemon-reload)
+// and stopping/starting host GPU client services. On hosts where none of those
+// run - notably when WITH_SHUTDOWN_HOST_GPU_CLIENTS is false and no host state
+// file exists - the D-Bus socket is never dialed, so a systemd-less host does
+// not hang and the MIG geometry change (applied by the nvidia-mig-parted
+// binary, not via systemd) still completes.
 func (r *Reconfigure) getSystemdManager() (*systemd.Manager, error) {
 	if r.systemdManager != nil {
 		return r.systemdManager, nil
+	}
+
+	if len(r.opts.HostRootMount) > 0 {
+		hostSystemBusAddress := fmt.Sprintf("unix:path=%s/run/dbus/system_bus_socket", r.opts.HostRootMount)
+		_ = os.Setenv("DBUS_SYSTEM_BUS_ADDRESS", hostSystemBusAddress)
 	}
 
 	systemdManager, err := systemd.NewManager(r.ctx)

--- a/pkg/mig/reconfigure/reconfigure.go
+++ b/pkg/mig/reconfigure/reconfigure.go
@@ -19,6 +19,7 @@ package reconfigure
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -76,6 +77,7 @@ type Options struct {
 	DriverLibraryPath          string
 	NvidiaSMIPath              string
 	NvidiaCDIHookPath          string
+	SystemdTimeout             float64
 }
 
 // Reconfigure handles the MIG reconfiguration process
@@ -105,9 +107,14 @@ func New(ctx context.Context, clientset *kubernetes.Clientset, migPartedBinary [
 		_ = os.Setenv("DBUS_SYSTEM_BUS_ADDRESS", hostSystemBusAddress)
 	}
 
-	systemdManager, err := systemd.NewManager(ctx)
+	systemdManager, err := systemd.NewManager(ctx, time.Duration(opts.SystemdTimeout)*time.Second)
 	if err != nil {
-		return nil, fmt.Errorf("failed to initialize systemd manager: %w", err)
+		if errors.Is(err, context.DeadlineExceeded) {
+			log.Warn("connection to systemd timed out; skipping systemd-related tasks for this reconfiguration")
+			systemdManager = nil
+		} else {
+			return nil, fmt.Errorf("failed to initialize systemd manager: %w", err)
+		}
 	}
 
 	return &Reconfigure{
@@ -325,6 +332,10 @@ Environment="MIG_PARTED_SELECTED_CONFIG=%s"
 		return fmt.Errorf("failed to write config to state file: %w", err)
 	}
 
+	if r.systemdManager == nil {
+		return nil
+	}
+
 	return r.systemdManager.ReloadDaemon()
 }
 
@@ -414,6 +425,11 @@ func (r *Reconfigure) waitForPodsToBeDeleted() error {
 
 // shutdownHostGPUClients shuts down host GPU clients
 func (r *Reconfigure) shutdownHostGPUClients() error {
+	if r.systemdManager == nil {
+		log.Info("No systemd manager available, not shutting down GPU clients on the host")
+		return nil
+	}
+
 	log.Info("Shutting down all GPU clients on the host by stopping their systemd services")
 
 	services := strings.Split(r.opts.HostGPUClientServices, ",")
@@ -699,6 +715,11 @@ func (r *Reconfigure) createCDISpec() error {
 }
 
 func (r *Reconfigure) hostStartSystemdServices() error {
+	if r.systemdManager == nil {
+		log.Info("No systemd manager available, not starting anything via systemd")
+		return nil
+	}
+
 	services := r.stoppedServices
 	var restartServices []string
 	if len(services) == 0 {

--- a/pkg/mig/reconfigure/reconfigure.go
+++ b/pkg/mig/reconfigure/reconfigure.go
@@ -19,7 +19,6 @@ package reconfigure
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -107,23 +106,26 @@ func New(ctx context.Context, clientset *kubernetes.Clientset, migPartedBinary [
 		_ = os.Setenv("DBUS_SYSTEM_BUS_ADDRESS", hostSystemBusAddress)
 	}
 
-	systemdManager, err := systemd.NewManager(ctx, time.Duration(opts.SystemdTimeout)*time.Second)
-	if err != nil {
-		if errors.Is(err, context.DeadlineExceeded) {
-			log.Warn("connection to systemd timed out; skipping systemd-related tasks for this reconfiguration")
-			systemdManager = nil
-		} else {
-			return nil, fmt.Errorf("failed to initialize systemd manager: %w", err)
-		}
-	}
-
 	return &Reconfigure{
 		ctx:             ctx,
 		clientset:       clientset,
 		migPartedBinary: migPartedBinary,
 		opts:            opts,
-		systemdManager:  systemdManager,
 	}, nil
+}
+
+func (r *Reconfigure) getSystemdManager() (*systemd.Manager, error) {
+	if r.systemdManager != nil {
+		return r.systemdManager, nil
+	}
+
+	systemdManager, err := systemd.NewManager(r.ctx, time.Duration(r.opts.SystemdTimeout)*time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize systemd manager: %w", err)
+	}
+
+	r.systemdManager = systemdManager
+	return systemdManager, nil
 }
 
 // Run executes the complete MIG reconfiguration process
@@ -244,8 +246,8 @@ func (r *Reconfigure) Run() error {
 
 // cleanup cleans up systemd managers
 func (r *Reconfigure) cleanup() {
-	if r.systemdManager != nil {
-		r.systemdManager.Close()
+	if mgr, _ := r.getSystemdManager(); mgr != nil {
+		mgr.Close()
 	}
 }
 
@@ -332,11 +334,12 @@ Environment="MIG_PARTED_SELECTED_CONFIG=%s"
 		return fmt.Errorf("failed to write config to state file: %w", err)
 	}
 
-	if r.systemdManager == nil {
-		return nil
+	mgr, err := r.getSystemdManager()
+	if err != nil {
+		return err
 	}
 
-	return r.systemdManager.ReloadDaemon()
+	return mgr.ReloadDaemon()
 }
 
 // checkMigModeChangeRequired checks if MIG mode change is required
@@ -425,15 +428,15 @@ func (r *Reconfigure) waitForPodsToBeDeleted() error {
 
 // shutdownHostGPUClients shuts down host GPU clients
 func (r *Reconfigure) shutdownHostGPUClients() error {
-	if r.systemdManager == nil {
-		log.Info("No systemd manager available, not shutting down GPU clients on the host")
-		return nil
+	mgr, err := r.getSystemdManager()
+	if err != nil {
+		return err
 	}
 
 	log.Info("Shutting down all GPU clients on the host by stopping their systemd services")
 
 	services := strings.Split(r.opts.HostGPUClientServices, ",")
-	stoppedServices, err := r.systemdManager.StopSystemdServices(services)
+	stoppedServices, err := mgr.StopSystemdServices(services)
 	if err != nil {
 		return fmt.Errorf("failed to stop host systemd services: %w", err)
 	}
@@ -715,9 +718,9 @@ func (r *Reconfigure) createCDISpec() error {
 }
 
 func (r *Reconfigure) hostStartSystemdServices() error {
-	if r.systemdManager == nil {
-		log.Info("No systemd manager available, not starting anything via systemd")
-		return nil
+	mgr, err := r.getSystemdManager()
+	if err != nil {
+		return err
 	}
 
 	services := r.stoppedServices
@@ -727,7 +730,7 @@ func (r *Reconfigure) hostStartSystemdServices() error {
 		services = strings.Split(r.opts.HostGPUClientServices, ",")
 
 		for _, service := range services {
-			serviceStatus, err := r.systemdManager.GetServiceStatus(service)
+			serviceStatus, err := mgr.GetServiceStatus(service)
 			if err != nil {
 				log.Infof("failed to get service status: %v\n", err)
 				continue
@@ -753,5 +756,5 @@ func (r *Reconfigure) hostStartSystemdServices() error {
 		restartServices = r.stoppedServices
 	}
 
-	return r.systemdManager.StartSystemdServices(restartServices)
+	return mgr.StartSystemdServices(restartServices)
 }

--- a/pkg/mig/reconfigure/reconfigure.go
+++ b/pkg/mig/reconfigure/reconfigure.go
@@ -76,7 +76,6 @@ type Options struct {
 	DriverLibraryPath          string
 	NvidiaSMIPath              string
 	NvidiaCDIHookPath          string
-	SystemdTimeout             float64
 }
 
 // Reconfigure handles the MIG reconfiguration process
@@ -119,7 +118,7 @@ func (r *Reconfigure) getSystemdManager() (*systemd.Manager, error) {
 		return r.systemdManager, nil
 	}
 
-	systemdManager, err := systemd.NewManager(r.ctx, time.Duration(r.opts.SystemdTimeout)*time.Second)
+	systemdManager, err := systemd.NewManager(r.ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize systemd manager: %w", err)
 	}

--- a/pkg/mig/reconfigure/reconfigure.go
+++ b/pkg/mig/reconfigure/reconfigure.go
@@ -19,7 +19,6 @@ package reconfigure
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -111,23 +110,26 @@ func New(ctx context.Context, clientset *kubernetes.Clientset, migPartedBinary [
 		_ = os.Setenv("DBUS_SYSTEM_BUS_ADDRESS", hostSystemBusAddress)
 	}
 
-	systemdManager, err := systemd.NewManager(ctx, time.Duration(opts.SystemdTimeout)*time.Second)
-	if err != nil {
-		if errors.Is(err, context.DeadlineExceeded) {
-			log.Warn("connection to systemd timed out; skipping systemd-related tasks for this reconfiguration")
-			systemdManager = nil
-		} else {
-			return nil, fmt.Errorf("failed to initialize systemd manager: %w", err)
-		}
-	}
-
 	return &Reconfigure{
 		ctx:             ctx,
 		clientset:       clientset,
 		migPartedBinary: migPartedBinary,
 		opts:            opts,
-		systemdManager:  systemdManager,
 	}, nil
+}
+
+func (r *Reconfigure) getSystemdManager() (*systemd.Manager, error) {
+	if r.systemdManager != nil {
+		return r.systemdManager, nil
+	}
+
+	systemdManager, err := systemd.NewManager(r.ctx, time.Duration(r.opts.SystemdTimeout)*time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize systemd manager: %w", err)
+	}
+
+	r.systemdManager = systemdManager
+	return systemdManager, nil
 }
 
 // Run executes the complete MIG reconfiguration process
@@ -250,8 +252,8 @@ func (r *Reconfigure) Run() error {
 
 // cleanup cleans up systemd managers
 func (r *Reconfigure) cleanup() {
-	if r.systemdManager != nil {
-		r.systemdManager.Close()
+	if mgr, _ := r.getSystemdManager(); mgr != nil {
+		mgr.Close()
 	}
 }
 
@@ -341,11 +343,12 @@ Environment="MIG_PARTED_SELECTED_CONFIG=%s"
 		return fmt.Errorf("failed to write config to state file: %w", err)
 	}
 
-	if r.systemdManager == nil {
-		return nil
+	mgr, err := r.getSystemdManager()
+	if err != nil {
+		return err
 	}
 
-	return r.systemdManager.ReloadDaemon()
+	return mgr.ReloadDaemon()
 }
 
 // checkMigModeChangeRequired checks if MIG mode change is required
@@ -442,15 +445,15 @@ func (r *Reconfigure) waitForPodsToBeDeleted() error {
 
 // shutdownHostGPUClients shuts down host GPU clients
 func (r *Reconfigure) shutdownHostGPUClients() error {
-	if r.systemdManager == nil {
-		log.Info("No systemd manager available, not shutting down GPU clients on the host")
-		return nil
+	mgr, err := r.getSystemdManager()
+	if err != nil {
+		return err
 	}
 
 	log.Info("Shutting down all GPU clients on the host by stopping their systemd services")
 
 	services := strings.Split(r.opts.HostGPUClientServices, ",")
-	stoppedServices, err := r.systemdManager.StopSystemdServices(services)
+	stoppedServices, err := mgr.StopSystemdServices(services)
 	if err != nil {
 		return fmt.Errorf("failed to stop host systemd services: %w", err)
 	}
@@ -768,9 +771,9 @@ func (r *Reconfigure) createCDISpec() error {
 }
 
 func (r *Reconfigure) hostStartSystemdServices() error {
-	if r.systemdManager == nil {
-		log.Info("No systemd manager available, not starting anything via systemd")
-		return nil
+	mgr, err := r.getSystemdManager()
+	if err != nil {
+		return err
 	}
 
 	services := r.stoppedServices
@@ -780,7 +783,7 @@ func (r *Reconfigure) hostStartSystemdServices() error {
 		services = strings.Split(r.opts.HostGPUClientServices, ",")
 
 		for _, service := range services {
-			serviceStatus, err := r.systemdManager.GetServiceStatus(service)
+			serviceStatus, err := mgr.GetServiceStatus(service)
 			if err != nil {
 				log.Infof("failed to get service status: %v\n", err)
 				continue
@@ -806,5 +809,5 @@ func (r *Reconfigure) hostStartSystemdServices() error {
 		restartServices = r.stoppedServices
 	}
 
-	return r.systemdManager.StartSystemdServices(restartServices)
+	return mgr.StartSystemdServices(restartServices)
 }

--- a/pkg/mig/reconfigure/reconfigure.go
+++ b/pkg/mig/reconfigure/reconfigure.go
@@ -259,8 +259,8 @@ func (r *Reconfigure) Run() error {
 
 // cleanup cleans up systemd managers
 func (r *Reconfigure) cleanup() {
-	if mgr, _ := r.getSystemdManager(); mgr != nil {
-		mgr.Close()
+	if r.systemdManager != nil {
+		r.systemdManager.Close()
 	}
 }
 

--- a/pkg/mig/reconfigure/reconfigure.go
+++ b/pkg/mig/reconfigure/reconfigure.go
@@ -19,6 +19,7 @@ package reconfigure
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -79,6 +80,7 @@ type Options struct {
 	DriverLibraryPath          string
 	NvidiaSMIPath              string
 	NvidiaCDIHookPath          string
+	SystemdTimeout             float64
 }
 
 // Reconfigure handles the MIG reconfiguration process
@@ -109,9 +111,14 @@ func New(ctx context.Context, clientset *kubernetes.Clientset, migPartedBinary [
 		_ = os.Setenv("DBUS_SYSTEM_BUS_ADDRESS", hostSystemBusAddress)
 	}
 
-	systemdManager, err := systemd.NewManager(ctx)
+	systemdManager, err := systemd.NewManager(ctx, time.Duration(opts.SystemdTimeout)*time.Second)
 	if err != nil {
-		return nil, fmt.Errorf("failed to initialize systemd manager: %w", err)
+		if errors.Is(err, context.DeadlineExceeded) {
+			log.Warn("connection to systemd timed out; skipping systemd-related tasks for this reconfiguration")
+			systemdManager = nil
+		} else {
+			return nil, fmt.Errorf("failed to initialize systemd manager: %w", err)
+		}
 	}
 
 	return &Reconfigure{
@@ -334,6 +341,10 @@ Environment="MIG_PARTED_SELECTED_CONFIG=%s"
 		return fmt.Errorf("failed to write config to state file: %w", err)
 	}
 
+	if r.systemdManager == nil {
+		return nil
+	}
+
 	return r.systemdManager.ReloadDaemon()
 }
 
@@ -431,6 +442,11 @@ func (r *Reconfigure) waitForPodsToBeDeleted() error {
 
 // shutdownHostGPUClients shuts down host GPU clients
 func (r *Reconfigure) shutdownHostGPUClients() error {
+	if r.systemdManager == nil {
+		log.Info("No systemd manager available, not shutting down GPU clients on the host")
+		return nil
+	}
+
 	log.Info("Shutting down all GPU clients on the host by stopping their systemd services")
 
 	services := strings.Split(r.opts.HostGPUClientServices, ",")
@@ -752,6 +768,11 @@ func (r *Reconfigure) createCDISpec() error {
 }
 
 func (r *Reconfigure) hostStartSystemdServices() error {
+	if r.systemdManager == nil {
+		log.Info("No systemd manager available, not starting anything via systemd")
+		return nil
+	}
+
 	services := r.stoppedServices
 	var restartServices []string
 	if len(services) == 0 {

--- a/pkg/mig/reconfigure/reconfigure.go
+++ b/pkg/mig/reconfigure/reconfigure.go
@@ -265,8 +265,8 @@ func (r *Reconfigure) Run() error {
 
 // cleanup cleans up systemd managers
 func (r *Reconfigure) cleanup() {
-	if mgr, _ := r.getSystemdManager(); mgr != nil {
-		mgr.Close()
+	if r.systemdManager != nil {
+		r.systemdManager.Close()
 	}
 }
 

--- a/pkg/mig/reconfigure/reconfigure.go
+++ b/pkg/mig/reconfigure/reconfigure.go
@@ -102,13 +102,7 @@ type Reconfigure struct {
 	stoppedServices       []string
 }
 
-// New creates a new Reconfigure instance.
-//
-// The connection to the host's systemd D-Bus is established lazily (see
-// systemdMgr), not here. Constructing a Reconfigure never dials D-Bus, so a
-// reconfiguration that does not touch host systemd - the common case, and the
-// only workable case on systemd-less hosts such as Talos Linux - never blocks
-// on an unresponsive system bus socket.
+// New creates a new Reconfigure instance
 func New(ctx context.Context, clientset *kubernetes.Clientset, migPartedBinary []string, opts *Options) (*Reconfigure, error) {
 	return &Reconfigure{
 		ctx:             ctx,
@@ -118,14 +112,7 @@ func New(ctx context.Context, clientset *kubernetes.Clientset, migPartedBinary [
 	}, nil
 }
 
-// getSystemdManager lazily establishes and caches the connection to the host's systemd
-// D-Bus. It is only ever called from code paths that genuinely need systemd:
-// persisting the host mig-manager state file (which triggers a daemon-reload)
-// and stopping/starting host GPU client services. On hosts where none of those
-// run - notably when WITH_SHUTDOWN_HOST_GPU_CLIENTS is false and no host state
-// file exists - the D-Bus socket is never dialed, so a systemd-less host does
-// not hang and the MIG geometry change (applied by the nvidia-mig-parted
-// binary, not via systemd) still completes.
+// getSystemdManager lazily establishes and caches the connection to the host's systemd D-Bus
 func (r *Reconfigure) getSystemdManager() (*systemd.Manager, error) {
 	if r.systemdManager != nil {
 		return r.systemdManager, nil

--- a/pkg/mig/reconfigure/reconfigure.go
+++ b/pkg/mig/reconfigure/reconfigure.go
@@ -79,7 +79,6 @@ type Options struct {
 	DriverLibraryPath          string
 	NvidiaSMIPath              string
 	NvidiaCDIHookPath          string
-	SystemdTimeout             float64
 }
 
 // Reconfigure handles the MIG reconfiguration process
@@ -123,7 +122,7 @@ func (r *Reconfigure) getSystemdManager() (*systemd.Manager, error) {
 		return r.systemdManager, nil
 	}
 
-	systemdManager, err := systemd.NewManager(r.ctx, time.Duration(r.opts.SystemdTimeout)*time.Second)
+	systemdManager, err := systemd.NewManager(r.ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize systemd manager: %w", err)
 	}

--- a/pkg/mig/reconfigure/reconfigure.go
+++ b/pkg/mig/reconfigure/reconfigure.go
@@ -102,13 +102,14 @@ type Reconfigure struct {
 	stoppedServices       []string
 }
 
-// New creates a new Reconfigure instance
+// New creates a new Reconfigure instance.
+//
+// The connection to the host's systemd D-Bus is established lazily (see
+// systemdMgr), not here. Constructing a Reconfigure never dials D-Bus, so a
+// reconfiguration that does not touch host systemd - the common case, and the
+// only workable case on systemd-less hosts such as Talos Linux - never blocks
+// on an unresponsive system bus socket.
 func New(ctx context.Context, clientset *kubernetes.Clientset, migPartedBinary []string, opts *Options) (*Reconfigure, error) {
-	if len(opts.HostRootMount) > 0 {
-		hostSystemBusAddress := fmt.Sprintf("unix:path=%s/run/dbus/system_bus_socket", opts.HostRootMount)
-		_ = os.Setenv("DBUS_SYSTEM_BUS_ADDRESS", hostSystemBusAddress)
-	}
-
 	return &Reconfigure{
 		ctx:             ctx,
 		clientset:       clientset,
@@ -117,9 +118,22 @@ func New(ctx context.Context, clientset *kubernetes.Clientset, migPartedBinary [
 	}, nil
 }
 
+// getSystemdManager lazily establishes and caches the connection to the host's systemd
+// D-Bus. It is only ever called from code paths that genuinely need systemd:
+// persisting the host mig-manager state file (which triggers a daemon-reload)
+// and stopping/starting host GPU client services. On hosts where none of those
+// run - notably when WITH_SHUTDOWN_HOST_GPU_CLIENTS is false and no host state
+// file exists - the D-Bus socket is never dialed, so a systemd-less host does
+// not hang and the MIG geometry change (applied by the nvidia-mig-parted
+// binary, not via systemd) still completes.
 func (r *Reconfigure) getSystemdManager() (*systemd.Manager, error) {
 	if r.systemdManager != nil {
 		return r.systemdManager, nil
+	}
+
+	if len(r.opts.HostRootMount) > 0 {
+		hostSystemBusAddress := fmt.Sprintf("unix:path=%s/run/dbus/system_bus_socket", r.opts.HostRootMount)
+		_ = os.Setenv("DBUS_SYSTEM_BUS_ADDRESS", hostSystemBusAddress)
 	}
 
 	systemdManager, err := systemd.NewManager(r.ctx)

--- a/pkg/mig/reconfigure/reconfigure_test.go
+++ b/pkg/mig/reconfigure/reconfigure_test.go
@@ -17,8 +17,68 @@
 package reconfigure
 
 import (
+	"context"
+	"path/filepath"
 	"testing"
 )
+
+// TestNewDoesNotConnectSystemd pins the core of the systemd-less-host fix:
+// constructing a Reconfigure must not dial the host's systemd D-Bus. On hosts
+// where the system bus socket exists but nothing answers (e.g. Talos Linux),
+// an eager connection here would block forever, so the connection has to be
+// established lazily instead.
+func TestNewDoesNotConnectSystemd(t *testing.T) {
+	opts := &Options{
+		NodeName:          "test-node",
+		SelectedMigConfig: "all-disabled",
+	}
+
+	r, err := New(context.Background(), nil, []string{"nvidia-mig-parted"}, opts)
+	if err != nil {
+		t.Fatalf("New returned an unexpected error: %v", err)
+	}
+	if r == nil {
+		t.Fatal("New returned a nil Reconfigure")
+	}
+	if r.systemdManager != nil {
+		t.Error("New must not establish a systemd D-Bus connection; systemdManager should be nil")
+	}
+}
+
+// TestSystemdMgrErrorIsNotCached verifies that when the lazy systemd connection
+// fails, the error is surfaced and nothing is cached, so a later call can try
+// again rather than reusing a broken (nil) manager.
+func TestSystemdMgrErrorIsNotCached(t *testing.T) {
+	// Point D-Bus at a socket that does not exist so the dial fails immediately
+	// (the missing-socket path returns fast, well before the connect timeout).
+	missing := "unix:path=" + filepath.Join(t.TempDir(), "does-not-exist")
+	t.Setenv("DBUS_SYSTEM_BUS_ADDRESS", missing)
+	t.Setenv("DBUS_LAUNCHD_SESSION_BUS_SOCKET", filepath.Join(t.TempDir(), "does-not-exist"))
+
+	r := &Reconfigure{
+		ctx:  context.Background(),
+		opts: &Options{},
+	}
+
+	mgr, err := r.getSystemdManager()
+	if err == nil {
+		t.Fatal("expected an error when the systemd D-Bus socket is unavailable, got nil")
+	}
+	if mgr != nil {
+		t.Errorf("expected a nil manager on error, got %v", mgr)
+	}
+	if r.systemdManager != nil {
+		t.Error("a failed connection must not be cached; systemdManager should remain nil")
+	}
+}
+
+// TestCleanupWithNilManager ensures the deferred cleanup is safe when a
+// reconfiguration completes without ever needing systemd (the common
+// systemd-less-host path, where the manager is never created).
+func TestCleanupWithNilManager(t *testing.T) {
+	r := &Reconfigure{}
+	r.cleanup() // must not panic
+}
 
 func TestMaybeSetPaused(t *testing.T) {
 	reconfigure := &Reconfigure{}

--- a/pkg/mig/reconfigure/reconfigure_test.go
+++ b/pkg/mig/reconfigure/reconfigure_test.go
@@ -22,11 +22,6 @@ import (
 	"testing"
 )
 
-// TestNewDoesNotConnectSystemd pins the core of the systemd-less-host fix:
-// constructing a Reconfigure must not dial the host's systemd D-Bus. On hosts
-// where the system bus socket exists but nothing answers (e.g. Talos Linux),
-// an eager connection here would block forever, so the connection has to be
-// established lazily instead.
 func TestNewDoesNotConnectSystemd(t *testing.T) {
 	opts := &Options{
 		NodeName:          "test-node",
@@ -45,12 +40,7 @@ func TestNewDoesNotConnectSystemd(t *testing.T) {
 	}
 }
 
-// TestSystemdMgrErrorIsNotCached verifies that when the lazy systemd connection
-// fails, the error is surfaced and nothing is cached, so a later call can try
-// again rather than reusing a broken (nil) manager.
 func TestSystemdMgrErrorIsNotCached(t *testing.T) {
-	// Point D-Bus at a socket that does not exist so the dial fails immediately
-	// (the missing-socket path returns fast, well before the connect timeout).
 	missing := "unix:path=" + filepath.Join(t.TempDir(), "does-not-exist")
 	t.Setenv("DBUS_SYSTEM_BUS_ADDRESS", missing)
 	t.Setenv("DBUS_LAUNCHD_SESSION_BUS_SOCKET", filepath.Join(t.TempDir(), "does-not-exist"))
@@ -72,9 +62,6 @@ func TestSystemdMgrErrorIsNotCached(t *testing.T) {
 	}
 }
 
-// TestCleanupWithNilManager ensures the deferred cleanup is safe when a
-// reconfiguration completes without ever needing systemd (the common
-// systemd-less-host path, where the manager is never created).
 func TestCleanupWithNilManager(t *testing.T) {
 	r := &Reconfigure{}
 	r.cleanup() // must not panic


### PR DESCRIPTION
# Motivation

Informally, this PR adds (partial) support for Talos. Closes #356.

More formally, this PR adds support for ~~systems with read-only filesystems and~~ systems that do not run `systemd`.

# Description

The MIG manager assumes that it will be able to copy the `mig-parted` binary to the host and use `systemd` to restart host-side GPU services. Neither of these is true for Talos, which is an immutable OS that doesn't run `systemd`. Proper Talos support would introduce a dependency on the Talos API, but that is beyond the scope of this PR and likely falls beyond the scope of what this tool should support.

~~This PR adds support for systems like Talos by introducing two new flags (both of which are required for Talos):~~

~~1. Identifying the host as read-only: prevent the manager from attempting to copy data to the host~~
~~2. Flagging the absence of `systemd`: tell the manager to skip all `systemd` operations that would otherwise cause the program to hang, since there would be no response on DBus~~

~~This PR includes `nil`-checks for the `systemd` manager that were not present before. In the original code, these checks are effectively unnecessary because this member is always initialized and the entire program blocks on this initialization if `systemd` is not present.~~

## Updated Description

In the interest of clarity for other users, here's an updated description of what this PR actually changes after all the discussion and how it relates to Talos.

This PR replaces the unconditional initialization of the `systemd` manager with a lazy initialization that includes a timeout. In a separate update to the GPU operator Helm chart, the `WITH_SHUTDOWN_HOST_GPU_CLIENTS` flag is decoupled from the flag indicating the presence of drivers on the host. The MIG manager already skips `systemd` operations when `WITH_SHUTDOWN_HOST_GPU_CLIENTS=false`. Together, these two changes remove the hard dependency on `systemd`, allowing the application to run on devices without `systemd`.

The decoupling of the flag also means that the MIG manager no longer tries to copy the `mig-parted` binary to the host just because host drivers are present. Note that this means that `WITH_SHUTDOWN_HOST_GPU_CLIENTS` must also be set to `false` when running on a read-only host. No changes in this PR are directly related to support for read-only systems.

# Improvements

This is the simplest possible solution to the problem described in the linked issue. All the MIG- and GPU-related operations work fine[^1] on Talos. We simply need to skip over the parts that can't work on Talos. The obvious alternatives or improvements over this PR are:

1. Specifically catching the "read-only FS" error when attempting to copy the binary instead of requiring a flag to skip the operation entirely
2. Detecting the presence or absence of `systemd`, either by inspecting the running processes or by introducing a timeout on the DBus connection, and adjusting accordingly, instead of requiring a flag

# Caveats

~~This PR exists more for discussion than with the goal of being merged.~~ These changes were made based on a very cursory reading and superficial understanding of the MIG manager. There is likely a cleaner and more elegant way to achieve this. However, I'll submit the patch as a proof-of-concept: by disabling the host-copies and all `systemd` features, the MIG manager works properly on Talos. This is, at least for us, an important starting point.

[^1]: CUDA validation yields `ERROR: init 250 result=11s`. I haven't yet figured out what this means, but so far it hasn't impacted the use of the GPU. The GPU workloads still run fine, as does the CUDA validation pod.