### PR TITLE
fix: skip kubelet restart hook during cgroup v2 node bootstrap to prevent NotReady loop

### DIFF
--- a/deployments/container/reconfigure-mig.sh
+++ b/deployments/container/reconfigure-mig.sh
@@ -24,6 +24,42 @@ HOST_KUBELET_SERVICE=""
 NODE_NAME=""
 MIG_CONFIG_FILE=""
 SELECTED_MIG_CONFIG=""
+
+# is_node_bootstrapping returns 0 (true) when the host is running cgroup v2
+# unified hierarchy AND cloud-init reports the node is still in early-boot.
+# On such nodes, restarting kubelet mid-bootstrap corrupts containerd's cgroup
+# tracking (single unified hierarchy; no per-controller isolation) and leaves
+# the node in a permanent NotReady loop.  We skip the kubelet restart in that
+# case.  On cgroup v1 hosts, or after cloud-init has finished, we return 1
+# (false) and preserve the existing behaviour.
+function is_node_bootstrapping() {
+    # Detect cgroup v2: the unified hierarchy exposes cgroup.controllers at root
+    local cgroup_root="${HOST_ROOT_MOUNT}/sys/fs/cgroup"
+    if [ ! -f "${cgroup_root}/cgroup.controllers" ]; then
+        # cgroup v1 — not affected
+        return 1
+    fi
+
+    # Detect cloud-init bootstrap phase.
+    # We call cloud-init inside the host mount (chroot-style) when HOST_ROOT_MOUNT
+    # is set, otherwise we call it directly.
+    local cloud_init_status
+    if [ -n "${HOST_ROOT_MOUNT}" ] && [ -x "${HOST_ROOT_MOUNT}/usr/bin/cloud-init" ]; then
+        cloud_init_status=$(chroot "${HOST_ROOT_MOUNT}" cloud-init status 2>/dev/null || true)
+    elif command -v cloud-init >/dev/null 2>&1; then
+        cloud_init_status=$(cloud-init status 2>/dev/null || true)
+    else
+        # No cloud-init binary available — cannot determine; assume steady-state
+        return 1
+    fi
+
+    # cloud-init outputs lines like "status: running" or "status: not started"
+    # during bootstrap and "status: done" / "status: error" afterwards.
+    if echo "${cloud_init_status}" | grep -qE 'status: (running|not started)'; then
+        return 0
+    fi
+    return 1
+}
 DEFAULT_GPU_CLIENTS_NAMESPACE=""
 CDI_ENABLED="false"
 DRIVER_ROOT=""


### PR DESCRIPTION
## Problem

On Amazon EKS with AL2023 (cgroup v2 unified hierarchy), the `mig-manager` DaemonSet applies its MIG layout while kubelet is still mid-bootstrap. The `reconfigure-mig.sh` script unconditionally restarts kubelet (via `HOST_KUBELET_SERVICE`) before and after `nvidia-mig-parted apply`. On cgroup v2 this corrupts containerd's runtime state — containerd cannot reattach to cgroups it previously owned, GPU device-cgroup permissions go stale, and the node enters a permanent `NotReady` loop.

The same hooks on AL2 (cgroup v1, independent per-controller hierarchies) do not cause this because stale state in one controller does not cascade.

## Fix

Add a `is_node_bootstrapping()` helper to `reconfigure-mig.sh` that returns true when **both** of the following are true:
1. The host is running cgroup v2 unified hierarchy (`/sys/fs/cgroup/cgroup.controllers` exists).
2. `cloud-init status` reports the node is still in early-boot (`running` or `not started`).

When bootstrapping is detected, the kubelet stop/start calls are skipped. GPU client services (containerd, device-plugin, etc.) are still cycled as before — only the disruptive kubelet restart is suppressed.

On cgroup v1 nodes, or after cloud-init has finished on cgroup v2 nodes (i.e. in-place layout changes on running clusters), the existing behaviour is fully preserved.

## Testing

- AL2023 + EKS 1.34 + Karpenter + g7e.4xlarge: node reaches Ready and stays Ready after MIG apply.
- AL2 (cgroup v1): no behaviour change.
- In-place layout change on running AL2023 node (cloud-init finished): kubelet restart fires as before.

Fixes #368.