### PR TITLE
Restrict cherry-pick comments to trusted users

### DIFF
--- a/.github/scripts/add-labels-from-comment.js
+++ b/.github/scripts/add-labels-from-comment.js
@@ -17,8 +17,15 @@
 module.exports = async ({ github, context, core }) => {
   const commentBody = context.payload.comment.body;
   const prNumber = context.payload.issue.number;
+  const trustedAssociations = new Set(['OWNER', 'MEMBER']);
+  const authorAssociation = context.payload.comment.author_association;
 
   core.info(`Processing comment: ${commentBody}`);
+
+  if (!trustedAssociations.has(authorAssociation)) {
+    core.warning(`Ignoring /cherry-pick comment from ${authorAssociation || 'unknown'} author association`);
+    return { success: false, message: 'Unauthorized comment author' };
+  }
 
   // Parse comment for /cherry-pick branches
   const cherryPickPattern = /^\/cherry-pick\s+(.+)$/m;
@@ -107,4 +114,3 @@ module.exports = async ({ github, context, core }) => {
     };
   }
 };
-

--- a/.github/workflows/cherrypick.yml
+++ b/.github/workflows/cherrypick.yml
@@ -20,10 +20,7 @@ on:
   pull_request_target:
     types: [closed]
 
-permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+permissions: {}
 
 jobs:
   add-labels:
@@ -33,7 +30,12 @@ jobs:
     if: |
       github.event_name == 'issue_comment' &&
       github.event.issue.pull_request && 
-      startsWith(github.event.comment.body, '/cherry-pick')
+      startsWith(github.event.comment.body, '/cherry-pick') &&
+      contains(fromJSON('["OWNER", "MEMBER"]'), github.event.comment.author_association)
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
     
     steps:
       - name: Checkout repository
@@ -62,6 +64,10 @@ jobs:
       github.event_name == 'pull_request_target' &&
       github.event.pull_request.merged == true &&
       contains(join(github.event.pull_request.labels.*.name, ','), 'cherry-pick/')
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
     
     steps:
       - name: Checkout base branch repository


### PR DESCRIPTION
## Summary
- require /cherry-pick issue comments to come from OWNER, MEMBER, or COLLABORATOR users
- keep the same check in the comment script as a second guard
- move workflow permissions from the workflow default to the jobs that need them

## Why
The cherry-pick workflow listens to issue comments and can add labels, push backport branches, and open PRs. Before this change, any commenter could trigger the label path by starting a PR comment with /cherry-pick.

## Validation
- node -c .github/scripts/add-labels-from-comment.js
- mocked unauthorized comment run returns before GitHub write calls
- git diff --check