### PR TITLE
Start driver services non-blocking during boot to avoid deadlock

### DIFF
--- a/deployments/systemd/hooks.sh
+++ b/deployments/systemd/hooks.sh
@@ -92,7 +92,21 @@ function stop_driver_services() {
 }
 
 function start_driver_services() {
-	nvidia-mig-manager::service::start_systemd_services driver_services
+	# Driver services are ordered After=nvidia-gpu-reset.target, and this
+	# service runs Before that target. During boot, starting them
+	# synchronously here deadlocks: this service waits on them while the
+	# target (and therefore those services) waits on this service to finish.
+	# While the system is still starting up, enqueue the start without
+	# waiting; systemd starts them once this service completes and the target
+	# is reached. Once the system is running, start synchronously as before so
+	# a runtime reconfigure still waits for the services and reports failures.
+	local start_args=""
+	local state
+	state="$(systemctl is-system-running 2>/dev/null)"
+	if [ "${state}" != "running" ] && [ "${state}" != "degraded" ]; then
+		start_args="--no-block"
+	fi
+	nvidia-mig-manager::service::start_systemd_services driver_services "${start_args}"
 	return ${?}
 }
 

--- a/deployments/systemd/utils.sh
+++ b/deployments/systemd/utils.sh
@@ -90,12 +90,13 @@ function nvidia-mig-manager::service::persist_config_across_reboot() {
 
 function nvidia-mig-manager::service::start_systemd_services() {
 	local -n __services="${1}"
+	local extra_args="${2:-}"
 	for s in ${__services[@]}; do
 		systemctl list-unit-files --state=enabled,generated | grep -F "${s}"
 		if [ "${?}" != "0" ]; then
 			continue
 		fi
-		systemctl start "${s}"
+		systemctl start ${extra_args} "${s}"
 		if [ "${?}" != "0" ]; then
 			return 1
 		fi


### PR DESCRIPTION
`nvidia-mig-manager.service` runs `Before=nvidia-gpu-reset.target`, while the
driver services it restarts (nvsm, nvidia-dcgm) are ordered After that
target. The `apply-exit` hook started them with a blocking `systemctl
start`, which deadlocks during boot: the service waits for the start to
finish, but the target -- and therefore those services -- cannot start
until the service itself completes.

Before commit db06e54e, service.sh did not default MIG_PARTED_HOOKS_FILE, so under
systemd the hooks were silently skipped and apply-exit never started the
driver services. Once that fix landed (v0.14.0), apply-exit began running
`systemctl start nvsm.service` during boot, which exposed the ordering
deadlock.

Use `systemctl is-system-running` to detect that the system is still
starting and enqueue the start with `--no-block` in that case, letting
the service finish so systemd brings the driver services up once the
target is reached. Once the system is running (a runtime reconfigure),
start synchronously as before so the apply still waits for the services
and reports start failures.