### PR TITLE
Select the hooks file at boot instead of at install time

### DIFF
--- a/deployments/systemd/service.sh
+++ b/deployments/systemd/service.sh
@@ -18,6 +18,11 @@ CURRDIR="$(cd "$( dirname $(readlink -f "${BASH_SOURCE[0]}"))" >/dev/null 2>&1 &
 
 source ${CURRDIR}/utils.sh
 
+# Select the appropriate hooks file now that the driver is loaded. The choice
+# made at package-install time can be wrong if the GPU was not queryable then
+# (e.g. during OS image builds).
+nvidia-mig-manager::service::select_hooks_file
+
 CONFIG_FILE="${CURRDIR}/config.yaml"
 DEFAULT_CONFIG_FILE="${CURRDIR}/config-default.yaml"
 

--- a/deployments/systemd/utils.sh
+++ b/deployments/systemd/utils.sh
@@ -88,6 +88,48 @@ function nvidia-mig-manager::service::persist_config_across_reboot() {
 	systemctl daemon-reload
 }
 
+function nvidia-mig-manager::service::select_hooks_file() {
+	local config_dir="/etc/nvidia-mig-manager"
+	local link="${config_dir}/hooks.yaml"
+
+	# Only manage the symlink when it is missing or points at one of the
+	# shipped hooks files. A hooks.yaml the user pointed elsewhere is left
+	# untouched.
+	if [ -e "${link}" ]; then
+		local target
+		target="$(readlink -f "${link}")"
+		if [ "${target}" != "${config_dir}/hooks-minimal.yaml" ] && \
+		   [ "${target}" != "${config_dir}/hooks-default.yaml" ]; then
+			return 0
+		fi
+	fi
+
+	# nvidia-smi can be absent when the package is installed (e.g. during OS
+	# image builds), which leaves the symlink pointing at the fallback hooks
+	# file. The driver is loaded by the time this service runs, so re-evaluate
+	# the selection here. If nvidia-smi is still unavailable, keep the current
+	# symlink rather than guess.
+	if ! which nvidia-smi >/dev/null 2>&1; then
+		echo "Warning: nvidia-smi not available; keeping the current hooks file (${link})" >&2
+		return 0
+	fi
+
+	local compute_cap
+	compute_cap="$(nvidia-smi -i 0 --query-gpu=compute_cap --format=csv,noheader)"
+
+	local desired="hooks-default.yaml"
+	if [ "${compute_cap/./}" -ge "90" ] 2>/dev/null; then
+		desired="hooks-minimal.yaml"
+	fi
+
+	local current
+	current="$(readlink "${link}" 2>/dev/null)"
+	if [ "${current}" != "${desired}" ]; then
+		echo "Pointing ${link} at ${desired} (compute capability ${compute_cap})" >&2
+		ln -sf "${desired}" "${link}"
+	fi
+}
+
 function nvidia-mig-manager::service::start_systemd_services() {
 	local -n __services="${1}"
 	for s in ${__services[@]}; do


### PR DESCRIPTION
`maybe_add_hooks_symlink` picks `hooks.yaml` based on the GPU compute capability reported by `nvidia-smi` at 
**package-install time**. When `nvidia-smi` is unavailable then — as during OS image builds, where the driver is not 
yet present — it falls back to `hooks-default.yaml` even on Hopper/Blackwell GPUs that should use `hooks-minimal.yaml`, and it is never revisited (the postinst early-returns if the symlink exists, and upgrades preserve it).

Re-select the hooks file from `service.sh`, which runs `After=nvidia-persistenced.service` and therefore has the 
driver loaded. The new `select_hooks_file` helper re-evaluates the compute capability and repoints the symlink, but 
only when it is missing or points at one of the known hooks files, so a user-provided `hooks.yaml` is left untouched. 
If `nvidia-smi` is still unavailable it logs a warning and keeps the current symlink.

This is a follow-up to the boot deadlock fixed in #408.

Closes #409
