### PR TITLE
add oneshot services  timeout

### DIFF
--- a/deployments/systemd/nvidia-mig-manager.service
+++ b/deployments/systemd/nvidia-mig-manager.service
@@ -20,6 +20,7 @@ Before=nvidia-gpu-reset.target
 
 [Service]
 Type=oneshot
+TimeoutStartSec=900
 ExecStart=/bin/bash /etc/nvidia-mig-manager/service.sh
 
 [Install]

--- a/deployments/systemd/nvidia-mig-manager.service
+++ b/deployments/systemd/nvidia-mig-manager.service
@@ -20,6 +20,7 @@ Before=nvidia-gpu-reset.target
 
 [Service]
 Type=oneshot
+TimeoutStartSec=480
 ExecStart=/bin/bash /etc/nvidia-mig-manager/service.sh
 
 [Install]


### PR DESCRIPTION
Issue: [68](https://github.com/NVIDIA/mig-parted/issues/68) The nvidia-mig-manager systemd service is configured as Type=oneshot, meaning systemd waits for the service to complete before proceeding. The MIG partitioning operation can take longer than the default systemd startup timeout, causing the service to be killed prematurely and fail. GPU nodes with time-consuming MIG operations would silently fail at boot, leaving GPUs in an inconsistent state

Fix: This PR adds TimeoutStartSec=480 to deployments/systemd/nvidia-mig-manager.service, setting a 8 minute startup timeout so the oneshot service has sufficient time to complete MIG reconfiguration. If it exceeds that timeout window, systemd marks the service as failed and boots the system in a degraded state, giving the user an SSH shell to investigate.

