### PR TITLE
Restore /var/run symlink to /run in the container image

### DIFF
--- a/deployments/container/Dockerfile
+++ b/deployments/container/Dockerfile
@@ -72,6 +72,10 @@ USER 0:0
 
 COPY --from=shell /busybox /busybox
 RUN ["/busybox/ln", "-s", "/busybox/sh", "/bin/sh"]
+# nvidia-smi looks for the persistenced socket at /var/run/..., but the
+# container toolkit injects it at /run/... Symlink /var/run to /run so GPU
+# resets can use nvidia-persistenced.
+RUN ["/busybox/sh", "-c", "/busybox/rm -r /var/run && /busybox/ln -s /run /var/run"]
 ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/busybox
 
 COPY --from=build /artifacts/nvidia-mig-parted  /usr/bin/nvidia-mig-parted


### PR DESCRIPTION
nvidia-smi discovers the nvidia-persistenced socket at
`/var/run/nvidia-persistenced/socket`, while the container toolkit injects
it at `/run/nvidia-persistenced/socket`. Commit 3944439b symlinked
`/var/run to /run` so nvidia-smi can reach the socket and coordinate with
persistenced when resetting GPUs. The switch to the non-dev distroless
base in 19fe9af0 dropped that symlink, and the new base ships `/var/run`
as a plain empty directory, so GPU resets after a MIG mode change fail
with the GPU reported as in use by another client (nvidia-persistenced).

Recreate the symlink in the final image stage using the busybox applets,
since the non-dev base image has no shell of its own.

Fixes #429 