### PR TITLE
fix: prevent the MIG reconfigure from hanging on systemd-less hosts

### DIFF
--- a/internal/systemd/systemd.go
+++ b/internal/systemd/systemd.go
@@ -27,30 +27,85 @@ import (
 	"github.com/coreos/go-systemd/v22/dbus"
 )
 
+// systemdConnectTimeout bounds how long NewManager waits for the systemd D-Bus
+// connection (dial plus auth handshake) to be established. On hosts without a
+// running systemd/D-Bus daemon the system bus socket may still exist - for
+// example when /run/dbus/system_bus_socket is bind-mounted from the host - but
+// never answer, in which case the underlying auth handshake would otherwise
+// block forever. Bounding it turns that indefinite hang into a fast, actionable
+// error.
+const systemdConnectTimeout = 10 * time.Second
+
 // Manager handles systemd operations using the D-Bus API
 type Manager struct {
 	ctx context.Context
 
-	conn *dbus.Conn
+	conn   *dbus.Conn
+	cancel context.CancelFunc
 }
 
-// NewManager creates a new Manager instance
+// NewManager creates a new Manager instance connected to the systemd system
+// bus. It fails fast, rather than blocking indefinitely, when the D-Bus socket
+// exists but no systemd daemon is answering (as happens on systemd-less hosts
+// such as Talos Linux).
 func NewManager(ctx context.Context) (*Manager, error) {
-	conn, err := dbus.NewSystemConnectionContext(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to connect to systemd D-Bus: %w", err)
-	}
+	return newManagerWithTimeout(ctx, systemdConnectTimeout)
+}
 
-	return &Manager{
-		ctx:  ctx,
-		conn: conn,
-	}, nil
+// newManagerWithTimeout is the testable core of NewManager, with the connection
+// timeout injected so tests do not have to wait for the production default.
+func newManagerWithTimeout(ctx context.Context, timeout time.Duration) (*Manager, error) {
+	// Derive a cancelable context for the connection. go-systemd/godbus tie the
+	// lifetime of the connection to this context and, crucially, spawn a watcher
+	// goroutine that closes the underlying socket as soon as the context is done.
+	// We rely on that to unblock a stuck auth handshake: if the dial does not
+	// complete within the timeout we cancel the context, the socket is closed,
+	// and the blocked read returns an error instead of hanging forever.
+	connCtx, cancel := context.WithCancel(ctx)
+
+	type result struct {
+		conn *dbus.Conn
+		err  error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		conn, err := dbus.NewSystemConnectionContext(connCtx)
+		ch <- result{conn: conn, err: err}
+	}()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case res := <-ch:
+		if res.err != nil {
+			cancel()
+			return nil, fmt.Errorf("failed to connect to systemd D-Bus: %w", res.err)
+		}
+		// Success: the connection (and connCtx) must outlive this call, so we do
+		// not cancel here. cancel is retained and invoked by Close().
+		return &Manager{
+			ctx:    ctx,
+			conn:   res.conn,
+			cancel: cancel,
+		}, nil
+	case <-timer.C:
+		// The dial is stuck: the socket exists but nothing is answering, as on a
+		// systemd-less host. Cancel the connection context so the godbus watcher
+		// closes the socket and unblocks the goroutine above, then report a clear
+		// error instead of hanging.
+		cancel()
+		return nil, fmt.Errorf("timed out after %s connecting to systemd D-Bus: the system bus socket exists but is not responding (is this a systemd-less host?)", timeout)
+	}
 }
 
 // Close closes the D-Bus connection
 func (sm *Manager) Close() error {
 	if sm.conn != nil {
 		sm.conn.Close()
+	}
+	if sm.cancel != nil {
+		sm.cancel()
 	}
 	return nil
 }

--- a/internal/systemd/systemd_test.go
+++ b/internal/systemd/systemd_test.go
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package systemd
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// setBusAddress points the D-Bus client library at socketPath for the duration
+// of the test. godbus resolves the system bus address from different
+// environment variables depending on the platform (DBUS_SYSTEM_BUS_ADDRESS on
+// Linux, DBUS_LAUNCHD_SESSION_BUS_SOCKET on macOS), so we set both to keep the
+// test portable between the CI runners and local development machines.
+func setBusAddress(t *testing.T, socketPath string) {
+	t.Helper()
+	t.Setenv("DBUS_SYSTEM_BUS_ADDRESS", "unix:path="+socketPath)
+	t.Setenv("DBUS_LAUNCHD_SESSION_BUS_SOCKET", socketPath)
+}
+
+// shortSocketPath returns a socket path in a fresh temp dir kept short enough to
+// stay under the ~104 byte sun_path limit for unix domain sockets (t.TempDir()
+// embeds the test name and can overflow that limit on macOS).
+func shortSocketPath(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "migp")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return filepath.Join(dir, "s")
+}
+
+// TestNewManagerWithTimeoutUnresponsiveSocket reproduces the systemd-less-host
+// failure mode: a system bus socket that exists (something is listening) but
+// never answers the D-Bus auth handshake. Before the fix this blocked forever;
+// NewManager must instead fail fast once the connect timeout elapses.
+func TestNewManagerWithTimeoutUnresponsiveSocket(t *testing.T) {
+	socketPath := shortSocketPath(t)
+
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("failed to listen on unix socket %q: %v", socketPath, err)
+	}
+	defer listener.Close()
+
+	// Accept connections but never write a reply, mimicking a bind-mounted host
+	// socket with no systemd/D-Bus daemon behind it.
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			// Hold the connection open without responding.
+			t.Cleanup(func() { _ = conn.Close() })
+		}
+	}()
+
+	setBusAddress(t, socketPath)
+
+	const timeout = 300 * time.Millisecond
+	start := time.Now()
+	mgr, err := newManagerWithTimeout(context.Background(), timeout)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		_ = mgr.Close()
+		t.Fatal("expected an error connecting to an unresponsive D-Bus socket, got nil")
+	}
+	if mgr != nil {
+		t.Errorf("expected a nil manager on error, got %v", mgr)
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Errorf("expected a timeout error, got: %v", err)
+	}
+	// The call must return promptly after the timeout, not hang. A generous
+	// upper bound still catches a regression back to the indefinite block.
+	if elapsed > 5*time.Second {
+		t.Errorf("connect took %s, expected it to fail fast near the %s timeout", elapsed, timeout)
+	}
+}
+
+// TestNewManagerWithTimeoutMissingSocket verifies that a missing socket fails
+// immediately via the dial error path, well before the connect timeout - i.e.
+// the timeout is a backstop, not the primary error path.
+func TestNewManagerWithTimeoutMissingSocket(t *testing.T) {
+	// A path that does not exist: the dial fails right away.
+	setBusAddress(t, filepath.Join(t.TempDir(), "does-not-exist"))
+
+	const timeout = 10 * time.Second
+	start := time.Now()
+	mgr, err := newManagerWithTimeout(context.Background(), timeout)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		_ = mgr.Close()
+		t.Fatal("expected an error connecting to a missing D-Bus socket, got nil")
+	}
+	if mgr != nil {
+		t.Errorf("expected a nil manager on error, got %v", mgr)
+	}
+	if strings.Contains(err.Error(), "timed out") {
+		t.Errorf("expected the immediate dial error, not the timeout error: %v", err)
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("connect to a missing socket took %s, expected it to fail immediately", elapsed)
+	}
+}
+
+// TestManagerCloseNil ensures Close is safe on a zero-value Manager (no
+// connection, no cancel func), matching how cleanup paths may call it.
+func TestManagerCloseNil(t *testing.T) {
+	var mgr Manager
+	if err := mgr.Close(); err != nil {
+		t.Errorf("Close on a zero-value Manager returned an error: %v", err)
+	}
+}

--- a/pkg/mig/reconfigure/reconfigure.go
+++ b/pkg/mig/reconfigure/reconfigure.go
@@ -98,25 +98,47 @@ type Reconfigure struct {
 	stoppedServices       []string
 }
 
-// New creates a new Reconfigure instance
+// New creates a new Reconfigure instance.
+//
+// The connection to the host's systemd D-Bus is established lazily (see
+// systemdMgr), not here. Constructing a Reconfigure never dials D-Bus, so a
+// reconfiguration that does not touch host systemd - the common case, and the
+// only workable case on systemd-less hosts such as Talos Linux - never blocks
+// on an unresponsive system bus socket.
 func New(ctx context.Context, clientset *kubernetes.Clientset, migPartedBinary []string, opts *Options) (*Reconfigure, error) {
-	if len(opts.HostRootMount) > 0 {
-		hostSystemBusAddress := fmt.Sprintf("unix:path=%s/run/dbus/system_bus_socket", opts.HostRootMount)
-		_ = os.Setenv("DBUS_SYSTEM_BUS_ADDRESS", hostSystemBusAddress)
-	}
-
-	systemdManager, err := systemd.NewManager(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize systemd manager: %w", err)
-	}
-
 	return &Reconfigure{
 		ctx:             ctx,
 		clientset:       clientset,
 		migPartedBinary: migPartedBinary,
 		opts:            opts,
-		systemdManager:  systemdManager,
 	}, nil
+}
+
+// systemdMgr lazily establishes and caches the connection to the host's systemd
+// D-Bus. It is only ever called from code paths that genuinely need systemd:
+// persisting the host mig-manager state file (which triggers a daemon-reload)
+// and stopping/starting host GPU client services. On hosts where none of those
+// run - notably when WITH_SHUTDOWN_HOST_GPU_CLIENTS is false and no host state
+// file exists - the D-Bus socket is never dialed, so a systemd-less host does
+// not hang and the MIG geometry change (applied by the nvidia-mig-parted
+// binary, not via systemd) still completes.
+func (r *Reconfigure) systemdMgr() (*systemd.Manager, error) {
+	if r.systemdManager != nil {
+		return r.systemdManager, nil
+	}
+
+	if len(r.opts.HostRootMount) > 0 {
+		hostSystemBusAddress := fmt.Sprintf("unix:path=%s/run/dbus/system_bus_socket", r.opts.HostRootMount)
+		_ = os.Setenv("DBUS_SYSTEM_BUS_ADDRESS", hostSystemBusAddress)
+	}
+
+	mgr, err := systemd.NewManager(r.ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize systemd manager: %w", err)
+	}
+
+	r.systemdManager = mgr
+	return mgr, nil
 }
 
 // Run executes the complete MIG reconfiguration process
@@ -325,7 +347,11 @@ Environment="MIG_PARTED_SELECTED_CONFIG=%s"
 		return fmt.Errorf("failed to write config to state file: %w", err)
 	}
 
-	return r.systemdManager.ReloadDaemon()
+	mgr, err := r.systemdMgr()
+	if err != nil {
+		return err
+	}
+	return mgr.ReloadDaemon()
 }
 
 // checkMigModeChangeRequired checks if MIG mode change is required
@@ -416,8 +442,13 @@ func (r *Reconfigure) waitForPodsToBeDeleted() error {
 func (r *Reconfigure) shutdownHostGPUClients() error {
 	log.Info("Shutting down all GPU clients on the host by stopping their systemd services")
 
+	mgr, err := r.systemdMgr()
+	if err != nil {
+		return err
+	}
+
 	services := strings.Split(r.opts.HostGPUClientServices, ",")
-	stoppedServices, err := r.systemdManager.StopSystemdServices(services)
+	stoppedServices, err := mgr.StopSystemdServices(services)
 	if err != nil {
 		return fmt.Errorf("failed to stop host systemd services: %w", err)
 	}
@@ -699,6 +730,11 @@ func (r *Reconfigure) createCDISpec() error {
 }
 
 func (r *Reconfigure) hostStartSystemdServices() error {
+	mgr, err := r.systemdMgr()
+	if err != nil {
+		return err
+	}
+
 	services := r.stoppedServices
 	var restartServices []string
 	if len(services) == 0 {
@@ -706,7 +742,7 @@ func (r *Reconfigure) hostStartSystemdServices() error {
 		services = strings.Split(r.opts.HostGPUClientServices, ",")
 
 		for _, service := range services {
-			serviceStatus, err := r.systemdManager.GetServiceStatus(service)
+			serviceStatus, err := mgr.GetServiceStatus(service)
 			if err != nil {
 				log.Infof("failed to get service status: %v\n", err)
 				continue
@@ -732,5 +768,5 @@ func (r *Reconfigure) hostStartSystemdServices() error {
 		restartServices = r.stoppedServices
 	}
 
-	return r.systemdManager.StartSystemdServices(restartServices)
+	return mgr.StartSystemdServices(restartServices)
 }

--- a/pkg/mig/reconfigure/reconfigure_test.go
+++ b/pkg/mig/reconfigure/reconfigure_test.go
@@ -17,8 +17,68 @@
 package reconfigure
 
 import (
+	"context"
+	"path/filepath"
 	"testing"
 )
+
+// TestNewDoesNotConnectSystemd pins the core of the systemd-less-host fix:
+// constructing a Reconfigure must not dial the host's systemd D-Bus. On hosts
+// where the system bus socket exists but nothing answers (e.g. Talos Linux),
+// an eager connection here would block forever, so the connection has to be
+// established lazily instead.
+func TestNewDoesNotConnectSystemd(t *testing.T) {
+	opts := &Options{
+		NodeName:          "test-node",
+		SelectedMigConfig: "all-disabled",
+	}
+
+	r, err := New(context.Background(), nil, []string{"nvidia-mig-parted"}, opts)
+	if err != nil {
+		t.Fatalf("New returned an unexpected error: %v", err)
+	}
+	if r == nil {
+		t.Fatal("New returned a nil Reconfigure")
+	}
+	if r.systemdManager != nil {
+		t.Error("New must not establish a systemd D-Bus connection; systemdManager should be nil")
+	}
+}
+
+// TestSystemdMgrErrorIsNotCached verifies that when the lazy systemd connection
+// fails, the error is surfaced and nothing is cached, so a later call can try
+// again rather than reusing a broken (nil) manager.
+func TestSystemdMgrErrorIsNotCached(t *testing.T) {
+	// Point D-Bus at a socket that does not exist so the dial fails immediately
+	// (the missing-socket path returns fast, well before the connect timeout).
+	missing := "unix:path=" + filepath.Join(t.TempDir(), "does-not-exist")
+	t.Setenv("DBUS_SYSTEM_BUS_ADDRESS", missing)
+	t.Setenv("DBUS_LAUNCHD_SESSION_BUS_SOCKET", filepath.Join(t.TempDir(), "does-not-exist"))
+
+	r := &Reconfigure{
+		ctx:  context.Background(),
+		opts: &Options{},
+	}
+
+	mgr, err := r.systemdMgr()
+	if err == nil {
+		t.Fatal("expected an error when the systemd D-Bus socket is unavailable, got nil")
+	}
+	if mgr != nil {
+		t.Errorf("expected a nil manager on error, got %v", mgr)
+	}
+	if r.systemdManager != nil {
+		t.Error("a failed connection must not be cached; systemdManager should remain nil")
+	}
+}
+
+// TestCleanupWithNilManager ensures the deferred cleanup is safe when a
+// reconfiguration completes without ever needing systemd (the common
+// systemd-less-host path, where the manager is never created).
+func TestCleanupWithNilManager(t *testing.T) {
+	r := &Reconfigure{}
+	r.cleanup() // must not panic
+}
 
 func TestMaybeSetPaused(t *testing.T) {
 	reconfigure := &Reconfigure{}


### PR DESCRIPTION
## What

On hosts without systemd — notably Talos Linux — `k8s-mig-manager` v0.14.0 hangs indefinitely when the `nvidia.com/mig.config` label changes, and never applies the new MIG geometry.

The Go-native reconfigure path opens a systemd D-Bus connection unconditionally when it is constructed. On a systemd-less host the system bus socket (`/run/dbus/system_bus_socket`) still exists — it is bind-mounted from the host — but nothing answers it, so the D-Bus auth handshake performs a blocking read that never returns. This happens even when `WITH_SHUTDOWN_HOST_GPU_CLIENTS=false`, i.e. when no host-systemd work is actually required.

## Why it matters

Most of the reconfigure flow does not need systemd at all — the MIG geometry change is applied by the `nvidia-mig-parted` binary, not through systemd. systemd is only needed to persist the host mig-manager state file (a daemon-reload) and to stop/restart host GPU client services. A host that never touches those paths should never need a D-Bus connection.

## Changes

- Connect to systemd D-Bus lazily. Constructing the reconfigurer no longer dials D-Bus; the connection is established (and cached) the first time a code path genuinely needs systemd. On the common systemd-less path the socket is never dialed, so the reconfigure completes.
- Bound the D-Bus connection setup with a timeout, as a backstop for the paths that do require systemd. If the socket is unresponsive, the connection attempt now fails fast with a clear error instead of blocking forever.

## Testing

- Unit tests added for the connection timeout (fast failure on an unresponsive socket, immediate failure on a missing socket) and for the lazy behavior (construction does not dial; a failed connection is not cached; cleanup is safe when systemd was never used).
- `go build ./...`, `go vet`, `gofmt`, and `golangci-lint` pass on the changed packages.
- End-to-end behavior on an actual systemd-less GPU host (Talos) cannot be exercised in CI; it requires the target hardware and OS.

Addresses #356
