### PR TITLE
Support optional subsystem ID matching in device filters

### DIFF
--- a/api/spec/v1/helpers.go
+++ b/api/spec/v1/helpers.go
@@ -38,7 +38,7 @@ func (ms *MigConfigSpec) MatchesDeviceFilter(deviceID types.DeviceID) bool {
 
 	for _, df := range deviceFilter {
 		newDeviceID, _ := types.NewDeviceIDFromString(df)
-		if newDeviceID == deviceID {
+		if newDeviceID.Matches(deviceID) {
 			return true
 		}
 	}

--- a/api/spec/v1/helpers_test.go
+++ b/api/spec/v1/helpers_test.go
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/NVIDIA/mig-parted/pkg/types"
+)
+
+func TestMigConfigSpecMatchesDeviceFilter(t *testing.T) {
+	h100 := types.NewDeviceIDWithSubsystem(0x2330, 0x10DE, 0x16C0, 0x10DE)
+
+	testCases := []struct {
+		name   string
+		filter interface{}
+		want   bool
+	}{
+		{
+			name:   "empty filter matches all devices",
+			filter: "",
+			want:   true,
+		},
+		{
+			name:   "primary-only filter matches subsystem-aware hardware",
+			filter: "0x233010DE",
+			want:   true,
+		},
+		{
+			name:   "matching subsystem filter matches hardware",
+			filter: "0x233010DE:0x16C010DE",
+			want:   true,
+		},
+		{
+			name:   "sibling subsystem filter does not match hardware",
+			filter: "0x233010DE:0x16C110DE",
+			want:   false,
+		},
+		{
+			name:   "multiple filters stop at a matching subsystem entry",
+			filter: []string{"0x233010DE:0x16C110DE", "0x233010DE:0x16C010DE"},
+			want:   true,
+		},
+		{
+			name:   "malformed filters with extra separators do not match",
+			filter: "0x233010DE:0x16C010DE:extra",
+			want:   false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := MigConfigSpec{
+				DeviceFilter: tc.filter,
+				Devices:      "all",
+			}
+
+			require.Equal(t, tc.want, spec.MatchesDeviceFilter(h100))
+		})
+	}
+}

--- a/cmd/nvidia-mig-parted/export/config.go
+++ b/cmd/nvidia-mig-parted/export/config.go
@@ -50,7 +50,8 @@ func ExportMigConfigs(c *Context) (*v1.Spec, error) {
 
 	configSpecs := make(v1.MigConfigSpecSlice, len(deviceIDs))
 	for i, deviceID := range deviceIDs {
-		deviceFilter := deviceID.String()
+		// Strip any subsystem qualifier so exported configs apply to all board variants of a GPU.
+		deviceFilter := deviceID.Primary().String()
 
 		enabled := false
 		capable, err := modeManager.IsMigCapable(i)

--- a/cmd/nvidia-mig-parted/util/device.go
+++ b/cmd/nvidia-mig-parted/util/device.go
@@ -67,7 +67,7 @@ func pciVisitGPUs(visit func(*nvpci.NvidiaPCIDevice) error) error {
 func pciGetGPUDeviceIDs() ([]types.DeviceID, error) {
 	var ids []types.DeviceID
 	err := pciVisitGPUs(func(gpu *nvpci.NvidiaPCIDevice) error {
-		ids = append(ids, types.NewDeviceID(gpu.Device, gpu.Vendor))
+		ids = append(ids, types.NewDeviceIDWithSubsystem(gpu.Device, gpu.Vendor, gpu.SubsystemDevice, gpu.SubsystemVendor))
 		return nil
 	})
 	if err != nil {
@@ -91,7 +91,7 @@ func nvmlGetGPUDeviceIDs() ([]types.DeviceID, error) {
 			return nil
 		}
 
-		ids = append(ids, types.NewDeviceID(gpu.Device, gpu.Vendor))
+		ids = append(ids, types.NewDeviceIDWithSubsystem(gpu.Device, gpu.Vendor, gpu.SubsystemDevice, gpu.SubsystemVendor))
 		return nil
 	})
 	if err != nil {

--- a/pkg/mig/config/known_configs.go
+++ b/pkg/mig/config/known_configs.go
@@ -23,8 +23,8 @@ import (
 	"github.com/NVIDIA/mig-parted/pkg/types"
 )
 
-const (
-	A100_SXM4_40GB types.DeviceID = 0x20B010DE
+var (
+	A100_SXM4_40GB = types.NewDeviceID(0x20B0, 0x10DE)
 )
 
 type LoopControl int

--- a/pkg/mig/discovery/discovery.go
+++ b/pkg/mig/discovery/discovery.go
@@ -32,10 +32,10 @@ import (
 // could be discovered.
 var ErrNoProfilesDiscovered = errors.New("no MIG profiles discovered for MIG-capable GPUs")
 
-const (
+var (
 	// deviceIDA30 is the PCI device ID for A30-24GB GPUs.
 	// NVML has a bug that reports incorrect profiles for this GPU.
-	deviceIDA30 = 0x20B710DE
+	deviceIDA30 = types.NewDeviceID(0x20B7, 0x10DE)
 )
 
 // ProfileInfo represents a discovered MIG profile with its metadata
@@ -65,9 +65,9 @@ func isCIProfile(c, g int) bool {
 func getDeviceID(dev nvdev.Device) (types.DeviceID, error) {
 	pciInfo, ret := nvml.Device(dev).GetPciInfo()
 	if ret != nvml.SUCCESS {
-		return 0, fmt.Errorf("failed to get PCI info: %v", ret)
+		return types.DeviceID{}, fmt.Errorf("failed to get PCI info: %v", ret)
 	}
-	return types.DeviceID(pciInfo.PciDeviceId), nil
+	return types.NewDeviceIDFromPacked(pciInfo.PciDeviceId), nil
 }
 
 // getHardcodedA30Profiles returns hardcoded MIG profiles for A30 GPUs.
@@ -132,7 +132,7 @@ func (d *discoverer) discoverProfiles() (DeviceProfiles, error) {
 		// Check for A30 - use hardcoded profiles due to NVML bug where
 		// GetGpuInstanceProfileInfo returns incorrect InstanceCount values.
 		// The hardcoded values match the A30 MIG profiles from nvidia-smi.
-		if uint32(deviceID) == deviceIDA30 {
+		if deviceIDA30.Matches(deviceID) {
 			log.Infof("Device %d is A30 (DeviceID: %s), using hardcoded profiles due to NVML bug",
 				i, deviceID.String())
 			result[i] = getHardcodedA30Profiles(deviceID)

--- a/pkg/mig/discovery/discovery_test.go
+++ b/pkg/mig/discovery/discovery_test.go
@@ -23,8 +23,6 @@ import (
 	"github.com/NVIDIA/go-nvml/pkg/nvml/mock/dgxa100"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/NVIDIA/mig-parted/pkg/types"
 )
 
 func TestDiscoverProfiles(t *testing.T) {
@@ -73,7 +71,7 @@ func TestIsCIProfile(t *testing.T) {
 }
 
 func TestGetHardcodedA30Profiles(t *testing.T) {
-	deviceID := types.DeviceID(deviceIDA30)
+	deviceID := deviceIDA30
 	profiles := getHardcodedA30Profiles(deviceID)
 
 	require.Len(t, profiles, 5)

--- a/pkg/types/device.go
+++ b/pkg/types/device.go
@@ -19,36 +19,124 @@ package types
 import (
 	"fmt"
 	"strconv"
+	"strings"
 )
 
 // DeviceID represents a GPU Device ID as read from a GPUs PCIe config space.
-type DeviceID uint32
+type DeviceID struct {
+	Device          uint16
+	Vendor          uint16
+	SubsystemDevice uint16
+	SubsystemVendor uint16
+	HasSubsystem    bool
+}
 
 // NewDeviceID constructs a new 'DeviceID' from the device and vendor values pulled from a GPUs PCIe config space.
 func NewDeviceID(device, vendor uint16) DeviceID {
-	return DeviceID((uint32(device) << 16) | uint32(vendor))
+	return DeviceID{
+		Device: device,
+		Vendor: vendor,
+	}
+}
+
+// NewDeviceIDWithSubsystem constructs a new 'DeviceID' with subsystem values.
+func NewDeviceIDWithSubsystem(device, vendor, subDevice, subVendor uint16) DeviceID {
+	return DeviceID{
+		Device:          device,
+		Vendor:          vendor,
+		SubsystemDevice: subDevice,
+		SubsystemVendor: subVendor,
+		HasSubsystem:    true,
+	}
+}
+
+// NewDeviceIDFromPacked constructs a 'DeviceID' from a combined 32-bit device+vendor
+// value, as reported in a GPUs PCIe config space or by NVML.
+func NewDeviceIDFromPacked(packed uint32) DeviceID {
+	device, vendor := splitRawDeviceID(uint64(packed))
+	return NewDeviceID(device, vendor)
 }
 
 // NewDeviceIDFromString constructs a 'DeviceID' from its string representation.
 func NewDeviceIDFromString(str string) (DeviceID, error) {
-	deviceID, err := strconv.ParseInt(str, 0, 32)
-	if err != nil {
-		return 0, fmt.Errorf("unable to create DeviceID from string '%v': %v", str, err)
+	parts := strings.Split(str, ":")
+	if len(parts) > 2 {
+		return DeviceID{}, fmt.Errorf(
+			"invalid DeviceID format '%v': expected '<devicevendor>' or '<devicevendor>:<subdevicevendor>'",
+			str,
+		)
 	}
-	return DeviceID(deviceID), nil
+
+	deviceIDRaw, err := strconv.ParseUint(parts[0], 0, 32)
+	if err != nil {
+		return DeviceID{}, fmt.Errorf("unable to create DeviceID from string '%v': %v", str, err)
+	}
+
+	device, vendor := splitRawDeviceID(deviceIDRaw)
+
+	deviceID := DeviceID{
+		Device: device,
+		Vendor: vendor,
+	}
+
+	if len(parts) == 2 {
+		subIDRaw, err := strconv.ParseUint(parts[1], 0, 32)
+		if err != nil {
+			return DeviceID{}, fmt.Errorf("unable to create Subsystem from string '%v': %v", str, err)
+		}
+
+		subsystemDevice, subsystemVendor := splitRawDeviceID(subIDRaw)
+
+		deviceID.SubsystemDevice = subsystemDevice
+		deviceID.SubsystemVendor = subsystemVendor
+		deviceID.HasSubsystem = true
+	}
+
+	return deviceID, nil
 }
 
 // String returns a 'DeviceID' as a string.
 func (d DeviceID) String() string {
-	return fmt.Sprintf("0x%X", uint32(d))
+	primary := fmt.Sprintf("0x%04X%04X", d.Device, d.Vendor)
+	if d.HasSubsystem {
+		return fmt.Sprintf("%s:0x%04X%04X", primary, d.SubsystemDevice, d.SubsystemVendor)
+	}
+	return primary
 }
 
 // GetVendor returns the 'vendor' portion of a 'DeviceID'.
 func (d DeviceID) GetVendor() uint16 {
-	return uint16(d)
+	return d.Vendor
 }
 
 // GetDevice returns the 'device' portion of a 'DeviceID'.
 func (d DeviceID) GetDevice() uint16 {
-	return uint16(d >> 16)
+	return d.Device
+}
+
+// Primary returns a copy of the 'DeviceID' with any subsystem qualification removed.
+func (d DeviceID) Primary() DeviceID {
+	return NewDeviceID(d.Device, d.Vendor)
+}
+
+// Matches checks if a hardware GPU matches the DeviceID filter.
+// If the filter has a subsystem defined, it requires an exact match on all 4 components.
+// Otherwise, it only matches on the primary device and vendor IDs.
+func (filter DeviceID) Matches(hardware DeviceID) bool {
+	if filter.Device != hardware.Device || filter.Vendor != hardware.Vendor {
+		return false
+	}
+
+	if filter.HasSubsystem {
+		if filter.SubsystemDevice != hardware.SubsystemDevice || filter.SubsystemVendor != hardware.SubsystemVendor {
+			return false
+		}
+	}
+
+	return true
+}
+
+func splitRawDeviceID(raw uint64) (uint16, uint16) {
+	// nolint:gosec // raw is parsed as a 32-bit value, so both halves fit in a uint16
+	return uint16(raw >> 16), uint16(raw & 0xFFFF)
 }

--- a/pkg/types/device_test.go
+++ b/pkg/types/device_test.go
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDeviceID(t *testing.T) {
+	require.Equal(t, DeviceID{
+		Device: 0x25B6,
+		Vendor: 0x10DE,
+	}, NewDeviceID(0x25B6, 0x10DE))
+}
+
+func TestNewDeviceIDWithSubsystem(t *testing.T) {
+	require.Equal(t, DeviceID{
+		Device:          0x25B6,
+		Vendor:          0x10DE,
+		SubsystemDevice: 0x14A9,
+		SubsystemVendor: 0x10DE,
+		HasSubsystem:    true,
+	}, NewDeviceIDWithSubsystem(0x25B6, 0x10DE, 0x14A9, 0x10DE))
+}
+
+func TestNewDeviceIDFromPacked(t *testing.T) {
+	require.Equal(t, NewDeviceID(0x25B6, 0x10DE), NewDeviceIDFromPacked(0x25B610DE))
+}
+
+func TestDeviceIDPrimary(t *testing.T) {
+	require.Equal(
+		t,
+		NewDeviceID(0x25B6, 0x10DE),
+		NewDeviceIDWithSubsystem(0x25B6, 0x10DE, 0x14A9, 0x10DE).Primary(),
+	)
+	require.Equal(t, NewDeviceID(0x25B6, 0x10DE), NewDeviceID(0x25B6, 0x10DE).Primary())
+}
+
+func TestNewDeviceIDFromString(t *testing.T) {
+	testCases := []struct {
+		name    string
+		input   string
+		want    DeviceID
+		wantErr string
+	}{
+		{
+			name:  "primary only",
+			input: "0x25B610DE",
+			want:  NewDeviceID(0x25B6, 0x10DE),
+		},
+		{
+			name:  "with subsystem",
+			input: "0x25B610DE:0x14A910DE",
+			want:  NewDeviceIDWithSubsystem(0x25B6, 0x10DE, 0x14A9, 0x10DE),
+		},
+		{
+			name:    "invalid primary",
+			input:   "not-a-device-id",
+			wantErr: "unable to create DeviceID",
+		},
+		{
+			name:    "invalid subsystem",
+			input:   "0x25B610DE:not-a-subsystem",
+			wantErr: "unable to create Subsystem",
+		},
+		{
+			name:    "too many separators",
+			input:   "0x25B610DE:0x14A910DE:extra",
+			wantErr: "invalid DeviceID format",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := NewDeviceIDFromString(tc.input)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tc.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestDeviceIDString(t *testing.T) {
+	require.Equal(t, "0x25B610DE", NewDeviceID(0x25B6, 0x10DE).String())
+	require.Equal(
+		t,
+		"0x25B610DE:0x14A910DE",
+		NewDeviceIDWithSubsystem(0x25B6, 0x10DE, 0x14A9, 0x10DE).String(),
+	)
+}
+
+func TestDeviceIDMatches(t *testing.T) {
+	a16 := NewDeviceIDWithSubsystem(0x25B6, 0x10DE, 0x14A9, 0x10DE)
+	a2 := NewDeviceIDWithSubsystem(0x25B6, 0x10DE, 0x157E, 0x10DE)
+
+	testCases := []struct {
+		name     string
+		filter   DeviceID
+		hardware DeviceID
+		want     bool
+	}{
+		{
+			name:     "primary only filter matches same primary id",
+			filter:   NewDeviceID(0x25B6, 0x10DE),
+			hardware: a16,
+			want:     true,
+		},
+		{
+			name:     "subsystem filter matches exact hardware",
+			filter:   NewDeviceIDWithSubsystem(0x25B6, 0x10DE, 0x14A9, 0x10DE),
+			hardware: a16,
+			want:     true,
+		},
+		{
+			name:     "subsystem filter rejects sibling subsystem",
+			filter:   NewDeviceIDWithSubsystem(0x25B6, 0x10DE, 0x14A9, 0x10DE),
+			hardware: a2,
+			want:     false,
+		},
+		{
+			name:     "subsystem filter does not match hardware with unknown subsystem",
+			filter:   NewDeviceIDWithSubsystem(0x25B6, 0x10DE, 0x14A9, 0x10DE),
+			hardware: NewDeviceIDWithSubsystem(0x25B6, 0x10DE, 0x0, 0x0),
+			want:     false,
+		},
+		{
+			name:     "zero subsystem filter matches hardware with unknown subsystem",
+			filter:   NewDeviceIDWithSubsystem(0x25B6, 0x10DE, 0x0, 0x0),
+			hardware: NewDeviceIDWithSubsystem(0x25B6, 0x10DE, 0x0, 0x0),
+			want:     true,
+		},
+		{
+			name:     "different primary id does not match",
+			filter:   NewDeviceID(0x1E30, 0x10DE),
+			hardware: a16,
+			want:     false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, tc.filter.Matches(tc.hardware))
+		})
+	}
+}


### PR DESCRIPTION
## Overview

Device filters identify GPUs by their PCI device and vendor IDs (e.g. `0x20B510DE`). Some GPU products share the same device ID and can only be distinguished by their PCI subsystem IDs, which makes it impossible to target one board variant with a MIG config today.

This PR adds optional subsystem ID matching to device filters:

- The device-filter format gains an optional subsystem component: `<device><vendor>[:<subsystem-device><subsystem-vendor>]`, e.g. `0x20B510DE:0x153710DE`.
- Filters without a subsystem component behave exactly as before and match every board variant of a GPU, so all existing configs are unaffected.
- `types.DeviceID` now carries subsystem device/vendor IDs, populated during GPU enumeration from PCIe config space (using the subsystem fields added in go-nvlib v0.12.0).

## Tested

I added unit tests covering the new filter parsing, string formatting, and matching semantics.

I also tested live on an A100 node by creating MIG configs with subsystem-qualified device filters (`0x20B510DE:0x153310DE`). I verified that a config block with the matching subsystem ID was applied (3g.40gb×2), that a config block with a sibling subsystem ID was correctly skipped, and that `nvidia-mig-parted apply` and `assert` behave unchanged with existing primary-only filters.
