### PR TITLE
Bump version to v0.14.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # NVIDIA MIG Manager Changelog
 
+## v0.14.5
+- Skip container runtime calls in hooks to avoid deadlocks
+- Add a start timeout of 480 seconds to nvidia-mig-manager.service
+- Bump k8s golang dependencies to v0.36.3
+- Bump distroless base image version to v4.0.9-dev
+
 ## v0.14.4
 - Start hook-managed systemd services with --no-block to avoid deadlocks
 - Bump golang.org/x/net to v0.55.0

--- a/deployments/container/nvidia-mig-manager-example-hopper-blackwell.yaml
+++ b/deployments/container/nvidia-mig-manager-example-hopper-blackwell.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: nvidia-mig-manager-service-account
       containers:
       - name: nvidia-mig-manager
-        image: nvcr.io/nvidia/cloud-native/k8s-mig-manager:v0.14.4
+        image: nvcr.io/nvidia/cloud-native/k8s-mig-manager:v0.14.5
         imagePullPolicy: IfNotPresent
         env:
         - name: NODE_NAME

--- a/deployments/container/nvidia-mig-manager-example.yaml
+++ b/deployments/container/nvidia-mig-manager-example.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: nvidia-mig-manager-service-account
       containers:
       - name: nvidia-mig-manager
-        image: nvcr.io/nvidia/cloud-native/k8s-mig-manager:v0.14.4
+        image: nvcr.io/nvidia/cloud-native/k8s-mig-manager:v0.14.5
         imagePullPolicy: IfNotPresent
         env:
         - name: NODE_NAME

--- a/versions.mk
+++ b/versions.mk
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 MODULE := github.com/NVIDIA/mig-parted
-VERSION ?= v0.14.4
+VERSION ?= v0.14.5
 
 vVERSION := v$(VERSION:v%=%)
 


### PR DESCRIPTION
In preparation for v0.14.5 release.

This patch release primarily contains these two changes:
- https://github.com/NVIDIA/mig-parted/pull/449
- https://github.com/NVIDIA/mig-parted/pull/422