### PR TITLE
[release-0.14] Add OCI standard image labels

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -68,7 +68,8 @@ jobs:
       - name: Build image
         env:
           IMAGE_NAME: ghcr.io/${LOWERCASE_REPO_OWNER}/k8s-mig-manager
-          VERSION: ${COMMIT_SHORT_SHA}-${{ matrix.arch }}
+          VERSION: ${COMMIT_SHORT_SHA}
+          IMAGE_TAG: ${COMMIT_SHORT_SHA}-${{ matrix.arch }}
           GOPROXY: ${{ steps.setup-go-proxy.outputs.goproxy-url }}
           DOCKER_BUILD_PLATFORM_OPTIONS: "--platform=linux/${{ matrix.arch }}"
         run: |

--- a/deployments/container/Dockerfile
+++ b/deployments/container/Dockerfile
@@ -74,12 +74,26 @@ ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_MIG_CONFIG_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=utility
 
+ARG VERSION
+ARG GIT_COMMIT
+ARG BUILD_TIMESTAMP
 LABEL version="${VERSION}"
 LABEL release="N/A"
 LABEL vendor="NVIDIA"
 LABEL io.k8s.display-name="NVIDIA MIG Manager for Kubernetes"
 LABEL name="NVIDIA MIG Manager for Kubernetes"
 LABEL summary="NVIDIA MIG Manager for Kubernetes"
-LABEL description="See summary"
+LABEL description="Automates MIG configuration of NVIDIA GPUs"
+
+LABEL org.opencontainers.base.name="nvcr.io/nvidia/distroless/go"
+LABEL org.opencontainers.image.created="${BUILD_TIMESTAMP}"
+LABEL org.opencontainers.image.description="Automates MIG configuration of NVIDIA GPUs"
+LABEL org.opencontainers.image.documentation="https://docs.nvidia.com/datacenter/cloud-native/gpu-operator"
+LABEL org.opencontainers.image.revision="${GIT_COMMIT}"
+LABEL org.opencontainers.image.source="https://github.com/NVIDIA/mig-parted.git"
+LABEL org.opencontainers.image.title="NVIDIA MIG Manager for Kubernetes"
+LABEL org.opencontainers.image.url="https://catalog.ngc.nvidia.com/orgs/nvidia/cloud-native/containers/k8s-mig-manager"
+LABEL org.opencontainers.image.vendor="NVIDIA"
+LABEL org.opencontainers.image.version="${VERSION}"
 
 ENTRYPOINT ["nvidia-mig-manager"]

--- a/deployments/container/Makefile
+++ b/deployments/container/Makefile
@@ -63,8 +63,9 @@ $(IMAGE_TARGETS): image-%: $(ARTIFACTS_ROOT)
 		$(DOCKER_BUILD_PLATFORM_OPTIONS) \
 		--tag $(IMAGE) \
 		--build-arg GOLANG_VERSION="$(GOLANG_VERSION)" \
-		--build-arg VERSION="$(vVERSION)" \
+		--build-arg VERSION="$(VERSION)" \
 		--build-arg GIT_COMMIT="$(GIT_COMMIT)" \
+		--build-arg BUILD_TIMESTAMP="$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")" \
 		--build-arg NVIDIA_CTK_VERSION=$(NVIDIA_CTK_VERSION) \
 		--build-arg CVE_UPDATES="$(CVE_UPDATES)" \
 		--build-arg GOPROXY="$(GOPROXY)" \

--- a/versions.mk
+++ b/versions.mk
@@ -15,8 +15,6 @@
 MODULE := github.com/NVIDIA/mig-parted
 VERSION ?= v0.14.5
 
-vVERSION := v$(VERSION:v%=%)
-
 GOLANG_VERSION := $(shell ./hack/golang-version.sh)
 
 BUILDIMAGE_TAG ?= devel-go$(GOLANG_VERSION)


### PR DESCRIPTION
Manual backport of #457 to `release-0.14` (the automated backport could not push because the commit modifies a workflow file, which the Actions token is not permitted to do).

Add org.opencontainers.image.* labels to the container image. The Makefile now passes a `BUILD_TIMESTAMP` build arg for the `image.created` label.

Declare the `VERSION` and `GIT_COMMIT` args in the final stage; they were previously out of scope there, so the existing `version` label expanded to an empty string.

CI builds previously produced version labels like `v<sha>-<arch>`. The workflow included the per-arch image tag into `VERSION` and the Makefile prepended a `v` via `vVERSION`. Set `VERSION` to the plain short SHA and pass the arch suffix via `IMAGE_TAG` instead. Pass `VERSION` into the build unmodified and drop the unused `vVERSION`.