### PR TITLE
Remove Go module versions from rendered TPN document

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -18,59 +18,59 @@ compiled busybox binary is added to the image, which is licensed under GPLv2.
 
 ## Runtime Dependency Index
 
-| Package | License | Module |
+| Package | License | Dependency |
 |---------|---------|--------|
-| `github.com/NVIDIA/go-nvlib/pkg` | Apache-2.0 | `github.com/NVIDIA/go-nvlib@v0.12.0` |
-| `github.com/NVIDIA/go-nvml/pkg/nvml` | Apache-2.0 | `github.com/NVIDIA/go-nvml@v0.13.3-1` |
-| `github.com/coreos/go-systemd/v22/dbus` | Apache-2.0 | `github.com/coreos/go-systemd/v22@v22.7.0` |
-| `github.com/davecgh/go-spew/spew` | ISC | `github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc` |
-| `github.com/emicklei/go-restful/v3` | MIT | `github.com/emicklei/go-restful/v3@v3.13.0` |
-| `github.com/fxamacker/cbor/v2` | MIT | `github.com/fxamacker/cbor/v2@v2.9.0` |
-| `github.com/go-logr/logr` | Apache-2.0 | `github.com/go-logr/logr@v1.4.3` |
-| `github.com/go-openapi/jsonpointer` | Apache-2.0 | `github.com/go-openapi/jsonpointer@v0.21.0` |
-| `github.com/go-openapi/jsonreference` | Apache-2.0 | `github.com/go-openapi/jsonreference@v0.20.2` |
-| `github.com/go-openapi/swag` | Apache-2.0 | `github.com/go-openapi/swag@v0.23.0` |
-| `github.com/godbus/dbus/v5` | BSD-2-Clause | `github.com/godbus/dbus/v5@v5.1.0` |
-| `github.com/google/gnostic-models` | Apache-2.0 | `github.com/google/gnostic-models@v0.7.0` |
-| `github.com/google/uuid` | BSD-3-Clause | `github.com/google/uuid@v1.6.0` |
-| `github.com/josharian/intern` | MIT | `github.com/josharian/intern@v1.0.0` |
-| `github.com/json-iterator/go` | MIT | `github.com/json-iterator/go@v1.1.12` |
-| `github.com/mailru/easyjson` | MIT | `github.com/mailru/easyjson@v0.7.7` |
-| `github.com/modern-go/concurrent` | Apache-2.0 | `github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd` |
-| `github.com/modern-go/reflect2` | Apache-2.0 | `github.com/modern-go/reflect2@v1.0.3-0.20250322232337-35a7c28c31ee` |
-| `github.com/munnerz/goautoneg` | BSD-3-Clause | `github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822` |
-| `github.com/pmezard/go-difflib/difflib` | BSD-3-Clause | `github.com/pmezard/go-difflib@v1.0.1-0.20181226105442-5d4384ee4fb2` |
-| `github.com/sirupsen/logrus` | MIT | `github.com/sirupsen/logrus@v1.9.4` |
-| `github.com/spf13/pflag` | BSD-3-Clause | `github.com/spf13/pflag@v1.0.9` |
-| `github.com/urfave/cli/v3` | MIT | `github.com/urfave/cli/v3@v3.10.1` |
-| `github.com/x448/float16` | MIT | `github.com/x448/float16@v0.8.4` |
-| `go.yaml.in/yaml/v2` | Apache-2.0 | `go.yaml.in/yaml/v2@v2.4.3` |
-| `go.yaml.in/yaml/v3` | MIT | `go.yaml.in/yaml/v3@v3.0.4` |
-| `golang.org/x/net` | BSD-3-Clause | `golang.org/x/net@v0.55.0` |
-| `golang.org/x/oauth2` | BSD-3-Clause | `golang.org/x/oauth2@v0.34.0` |
-| `golang.org/x/sys/unix` | BSD-3-Clause | `golang.org/x/sys@v0.47.0` |
-| `golang.org/x/term` | BSD-3-Clause | `golang.org/x/term@v0.43.0` |
-| `golang.org/x/text` | BSD-3-Clause | `golang.org/x/text@v0.37.0` |
-| `golang.org/x/time/rate` | BSD-3-Clause | `golang.org/x/time@v0.14.0` |
-| `google.golang.org/protobuf` | BSD-3-Clause | `google.golang.org/protobuf@v1.36.12-0.20260120151049-f2248ac996af` |
-| `gopkg.in/evanphx/json-patch.v4` | BSD-3-Clause | `gopkg.in/evanphx/json-patch.v4@v4.13.0` |
-| `gopkg.in/inf.v0` | BSD-3-Clause | `gopkg.in/inf.v0@v0.9.1` |
-| `gopkg.in/yaml.v2` | Apache-2.0 | `gopkg.in/yaml.v2@v2.4.0` |
-| `gopkg.in/yaml.v3` | MIT | `gopkg.in/yaml.v3@v3.0.1` |
-| `k8s.io/api` | Apache-2.0 | `k8s.io/api@v0.36.3` |
-| `k8s.io/apimachinery/pkg` | Apache-2.0 | `k8s.io/apimachinery@v0.36.3` |
-| `k8s.io/apimachinery/third_party/forked/golang` | BSD-3-Clause | `k8s.io/apimachinery@v0.36.3` |
-| `k8s.io/client-go` | Apache-2.0 | `k8s.io/client-go@v0.36.3` |
-| `k8s.io/klog/v2` | Apache-2.0 | `k8s.io/klog/v2@v2.140.0` |
-| `k8s.io/kube-openapi/pkg` | Apache-2.0 | `k8s.io/kube-openapi@v0.0.0-20260317180543-43fb72c5454a` |
-| `k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json` | BSD-3-Clause | `k8s.io/kube-openapi@v0.0.0-20260317180543-43fb72c5454a` |
-| `k8s.io/kube-openapi/pkg/validation/spec` | Apache-2.0 | `k8s.io/kube-openapi@v0.0.0-20260317180543-43fb72c5454a` |
-| `k8s.io/utils` | Apache-2.0 | `k8s.io/utils@v0.0.0-20260210185600-b8788abfbbc2` |
-| `k8s.io/utils/internal/third_party/forked/golang/net` | BSD-3-Clause | `k8s.io/utils@v0.0.0-20260210185600-b8788abfbbc2` |
-| `sigs.k8s.io/json` | Apache-2.0 / BSD-3-Clause | `sigs.k8s.io/json@v0.0.0-20250730193827-2d320260d730` |
-| `sigs.k8s.io/randfill` | Apache-2.0 | `sigs.k8s.io/randfill@v1.0.0` |
-| `sigs.k8s.io/structured-merge-diff/v6` | Apache-2.0 | `sigs.k8s.io/structured-merge-diff/v6@v6.3.3` |
-| `sigs.k8s.io/yaml` | Apache-2.0 / BSD-3-Clause / MIT | `sigs.k8s.io/yaml@v1.6.0` |
+| `github.com/NVIDIA/go-nvlib/pkg` | Apache-2.0 | `github.com/NVIDIA/go-nvlib` |
+| `github.com/NVIDIA/go-nvml/pkg/nvml` | Apache-2.0 | `github.com/NVIDIA/go-nvml` |
+| `github.com/coreos/go-systemd/v22/dbus` | Apache-2.0 | `github.com/coreos/go-systemd/v22` |
+| `github.com/davecgh/go-spew/spew` | ISC | `github.com/davecgh/go-spew` |
+| `github.com/emicklei/go-restful/v3` | MIT | `github.com/emicklei/go-restful/v3` |
+| `github.com/fxamacker/cbor/v2` | MIT | `github.com/fxamacker/cbor/v2` |
+| `github.com/go-logr/logr` | Apache-2.0 | `github.com/go-logr/logr` |
+| `github.com/go-openapi/jsonpointer` | Apache-2.0 | `github.com/go-openapi/jsonpointer` |
+| `github.com/go-openapi/jsonreference` | Apache-2.0 | `github.com/go-openapi/jsonreference` |
+| `github.com/go-openapi/swag` | Apache-2.0 | `github.com/go-openapi/swag` |
+| `github.com/godbus/dbus/v5` | BSD-2-Clause | `github.com/godbus/dbus/v5` |
+| `github.com/google/gnostic-models` | Apache-2.0 | `github.com/google/gnostic-models` |
+| `github.com/google/uuid` | BSD-3-Clause | `github.com/google/uuid` |
+| `github.com/josharian/intern` | MIT | `github.com/josharian/intern` |
+| `github.com/json-iterator/go` | MIT | `github.com/json-iterator/go` |
+| `github.com/mailru/easyjson` | MIT | `github.com/mailru/easyjson` |
+| `github.com/modern-go/concurrent` | Apache-2.0 | `github.com/modern-go/concurrent` |
+| `github.com/modern-go/reflect2` | Apache-2.0 | `github.com/modern-go/reflect2` |
+| `github.com/munnerz/goautoneg` | BSD-3-Clause | `github.com/munnerz/goautoneg` |
+| `github.com/pmezard/go-difflib/difflib` | BSD-3-Clause | `github.com/pmezard/go-difflib` |
+| `github.com/sirupsen/logrus` | MIT | `github.com/sirupsen/logrus` |
+| `github.com/spf13/pflag` | BSD-3-Clause | `github.com/spf13/pflag` |
+| `github.com/urfave/cli/v3` | MIT | `github.com/urfave/cli/v3` |
+| `github.com/x448/float16` | MIT | `github.com/x448/float16` |
+| `go.yaml.in/yaml/v2` | Apache-2.0 | `go.yaml.in/yaml/v2` |
+| `go.yaml.in/yaml/v3` | MIT | `go.yaml.in/yaml/v3` |
+| `golang.org/x/net` | BSD-3-Clause | `golang.org/x/net` |
+| `golang.org/x/oauth2` | BSD-3-Clause | `golang.org/x/oauth2` |
+| `golang.org/x/sys/unix` | BSD-3-Clause | `golang.org/x/sys` |
+| `golang.org/x/term` | BSD-3-Clause | `golang.org/x/term` |
+| `golang.org/x/text` | BSD-3-Clause | `golang.org/x/text` |
+| `golang.org/x/time/rate` | BSD-3-Clause | `golang.org/x/time` |
+| `google.golang.org/protobuf` | BSD-3-Clause | `google.golang.org/protobuf` |
+| `gopkg.in/evanphx/json-patch.v4` | BSD-3-Clause | `gopkg.in/evanphx/json-patch.v4` |
+| `gopkg.in/inf.v0` | BSD-3-Clause | `gopkg.in/inf.v0` |
+| `gopkg.in/yaml.v2` | Apache-2.0 | `gopkg.in/yaml.v2` |
+| `gopkg.in/yaml.v3` | MIT | `gopkg.in/yaml.v3` |
+| `k8s.io/api` | Apache-2.0 | `k8s.io/api` |
+| `k8s.io/apimachinery/pkg` | Apache-2.0 | `k8s.io/apimachinery` |
+| `k8s.io/apimachinery/third_party/forked/golang` | BSD-3-Clause | `k8s.io/apimachinery` |
+| `k8s.io/client-go` | Apache-2.0 | `k8s.io/client-go` |
+| `k8s.io/klog/v2` | Apache-2.0 | `k8s.io/klog/v2` |
+| `k8s.io/kube-openapi/pkg` | Apache-2.0 | `k8s.io/kube-openapi` |
+| `k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json` | BSD-3-Clause | `k8s.io/kube-openapi` |
+| `k8s.io/kube-openapi/pkg/validation/spec` | Apache-2.0 | `k8s.io/kube-openapi` |
+| `k8s.io/utils` | Apache-2.0 | `k8s.io/utils` |
+| `k8s.io/utils/internal/third_party/forked/golang/net` | BSD-3-Clause | `k8s.io/utils` |
+| `sigs.k8s.io/json` | Apache-2.0 / BSD-3-Clause | `sigs.k8s.io/json` |
+| `sigs.k8s.io/randfill` | Apache-2.0 | `sigs.k8s.io/randfill` |
+| `sigs.k8s.io/structured-merge-diff/v6` | Apache-2.0 | `sigs.k8s.io/structured-merge-diff/v6` |
+| `sigs.k8s.io/yaml` | Apache-2.0 / BSD-3-Clause / MIT | `sigs.k8s.io/yaml` |
 
 ## Bundled Binary Dependency Index
 
@@ -108,7 +108,7 @@ compiled busybox binary is added to the image, which is licensed under GPLv2.
 ### github.com/NVIDIA/go-nvlib/pkg
 
 * License: Apache-2.0
-* Module: github.com/NVIDIA/go-nvlib@v0.12.0
+* Dependency: github.com/NVIDIA/go-nvlib
 
 #### LICENSE
 
@@ -332,7 +332,7 @@ the PCI ID Project at https://pci-ids.ucw.cz/.
 ### github.com/NVIDIA/go-nvml/pkg/nvml
 
 * License: Apache-2.0
-* Module: github.com/NVIDIA/go-nvml@v0.13.3-1
+* Dependency: github.com/NVIDIA/go-nvml
 
 #### LICENSE
 
@@ -546,7 +546,7 @@ the PCI ID Project at https://pci-ids.ucw.cz/.
 ### github.com/coreos/go-systemd/v22/dbus
 
 * License: Apache-2.0
-* Module: github.com/coreos/go-systemd/v22@v22.7.0
+* Dependency: github.com/coreos/go-systemd/v22
 
 #### LICENSE
 
@@ -760,7 +760,7 @@ This product includes software developed at CoreOS, Inc.
 ### github.com/davecgh/go-spew/spew
 
 * License: ISC
-* Module: github.com/davecgh/go-spew@v1.1.2-0.20180830191138-d8f796af33cc
+* Dependency: github.com/davecgh/go-spew
 
 #### LICENSE
 
@@ -787,7 +787,7 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 ### github.com/emicklei/go-restful/v3
 
 * License: MIT
-* Module: github.com/emicklei/go-restful/v3@v3.13.0
+* Dependency: github.com/emicklei/go-restful/v3
 
 #### LICENSE
 
@@ -820,7 +820,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ### github.com/fxamacker/cbor/v2
 
 * License: MIT
-* Module: github.com/fxamacker/cbor/v2@v2.9.0
+* Dependency: github.com/fxamacker/cbor/v2
 
 #### LICENSE
 
@@ -852,7 +852,7 @@ SOFTWARE.
 ### github.com/go-logr/logr
 
 * License: Apache-2.0
-* Module: github.com/go-logr/logr@v1.4.3
+* Dependency: github.com/go-logr/logr
 
 #### LICENSE
 
@@ -1065,7 +1065,7 @@ SOFTWARE.
 ### github.com/go-openapi/jsonpointer
 
 * License: Apache-2.0
-* Module: github.com/go-openapi/jsonpointer@v0.21.0
+* Dependency: github.com/go-openapi/jsonpointer
 
 #### LICENSE
 
@@ -1279,7 +1279,7 @@ SOFTWARE.
 ### github.com/go-openapi/jsonreference
 
 * License: Apache-2.0
-* Module: github.com/go-openapi/jsonreference@v0.20.2
+* Dependency: github.com/go-openapi/jsonreference
 
 #### LICENSE
 
@@ -1493,7 +1493,7 @@ SOFTWARE.
 ### github.com/go-openapi/swag
 
 * License: Apache-2.0
-* Module: github.com/go-openapi/swag@v0.23.0
+* Dependency: github.com/go-openapi/swag
 
 #### LICENSE
 
@@ -1707,7 +1707,7 @@ SOFTWARE.
 ### github.com/godbus/dbus/v5
 
 * License: BSD-2-Clause
-* Module: github.com/godbus/dbus/v5@v5.1.0
+* Dependency: github.com/godbus/dbus/v5
 
 #### LICENSE
 
@@ -1744,7 +1744,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ### github.com/google/gnostic-models
 
 * License: Apache-2.0
-* Module: github.com/google/gnostic-models@v0.7.0
+* Dependency: github.com/google/gnostic-models
 
 #### LICENSE
 
@@ -1959,7 +1959,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ### github.com/google/uuid
 
 * License: BSD-3-Clause
-* Module: github.com/google/uuid@v1.6.0
+* Dependency: github.com/google/uuid
 
 #### LICENSE
 
@@ -1998,7 +1998,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ### github.com/josharian/intern
 
 * License: MIT
-* Module: github.com/josharian/intern@v1.0.0
+* Dependency: github.com/josharian/intern
 
 #### license.md
 
@@ -2031,7 +2031,7 @@ SOFTWARE.
 ### github.com/json-iterator/go
 
 * License: MIT
-* Module: github.com/json-iterator/go@v1.1.12
+* Dependency: github.com/json-iterator/go
 
 #### LICENSE
 
@@ -2064,7 +2064,7 @@ SOFTWARE.
 ### github.com/mailru/easyjson
 
 * License: MIT
-* Module: github.com/mailru/easyjson@v0.7.7
+* Dependency: github.com/mailru/easyjson
 
 #### LICENSE
 
@@ -2083,7 +2083,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 ### github.com/modern-go/concurrent
 
 * License: Apache-2.0
-* Module: github.com/modern-go/concurrent@v0.0.0-20180306012644-bacd9c7ef1dd
+* Dependency: github.com/modern-go/concurrent
 
 #### LICENSE
 
@@ -2296,7 +2296,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 ### github.com/modern-go/reflect2
 
 * License: Apache-2.0
-* Module: github.com/modern-go/reflect2@v1.0.3-0.20250322232337-35a7c28c31ee
+* Dependency: github.com/modern-go/reflect2
 
 #### LICENSE
 
@@ -2509,7 +2509,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 ### github.com/munnerz/goautoneg
 
 * License: BSD-3-Clause
-* Module: github.com/munnerz/goautoneg@v0.0.0-20191010083416-a7dc8b61c822
+* Dependency: github.com/munnerz/goautoneg
 
 #### LICENSE
 
@@ -2552,7 +2552,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ### github.com/pmezard/go-difflib/difflib
 
 * License: BSD-3-Clause
-* Module: github.com/pmezard/go-difflib@v1.0.1-0.20181226105442-5d4384ee4fb2
+* Dependency: github.com/pmezard/go-difflib
 
 #### LICENSE
 
@@ -2591,7 +2591,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ### github.com/sirupsen/logrus
 
 * License: MIT
-* Module: github.com/sirupsen/logrus@v1.9.4
+* Dependency: github.com/sirupsen/logrus
 
 #### LICENSE
 
@@ -2624,7 +2624,7 @@ THE SOFTWARE.
 ### github.com/spf13/pflag
 
 * License: BSD-3-Clause
-* Module: github.com/spf13/pflag@v1.0.9
+* Dependency: github.com/spf13/pflag
 
 #### LICENSE
 
@@ -2664,7 +2664,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ### github.com/urfave/cli/v3
 
 * License: MIT
-* Module: github.com/urfave/cli/v3@v3.10.1
+* Dependency: github.com/urfave/cli/v3
 
 #### LICENSE
 
@@ -2697,7 +2697,7 @@ SOFTWARE.
 ### github.com/x448/float16
 
 * License: MIT
-* Module: github.com/x448/float16@v0.8.4
+* Dependency: github.com/x448/float16
 
 #### LICENSE
 
@@ -2731,7 +2731,7 @@ SOFTWARE.
 ### go.yaml.in/yaml/v2
 
 * License: Apache-2.0
-* Module: go.yaml.in/yaml/v2@v2.4.3
+* Dependency: go.yaml.in/yaml/v2
 
 #### LICENSE
 
@@ -2963,7 +2963,7 @@ limitations under the License.
 ### go.yaml.in/yaml/v3
 
 * License: MIT
-* Module: go.yaml.in/yaml/v3@v3.0.4
+* Dependency: go.yaml.in/yaml/v3
 
 #### LICENSE
 
@@ -3044,7 +3044,7 @@ limitations under the License.
 ### golang.org/x/net
 
 * License: BSD-3-Clause
-* Module: golang.org/x/net@v0.55.0
+* Dependency: golang.org/x/net
 
 #### LICENSE
 
@@ -3083,7 +3083,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ### golang.org/x/oauth2
 
 * License: BSD-3-Clause
-* Module: golang.org/x/oauth2@v0.34.0
+* Dependency: golang.org/x/oauth2
 
 #### LICENSE
 
@@ -3122,7 +3122,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ### golang.org/x/sys/unix
 
 * License: BSD-3-Clause
-* Module: golang.org/x/sys@v0.47.0
+* Dependency: golang.org/x/sys
 
 #### LICENSE
 
@@ -3161,7 +3161,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ### golang.org/x/term
 
 * License: BSD-3-Clause
-* Module: golang.org/x/term@v0.43.0
+* Dependency: golang.org/x/term
 
 #### LICENSE
 
@@ -3200,7 +3200,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ### golang.org/x/text
 
 * License: BSD-3-Clause
-* Module: golang.org/x/text@v0.37.0
+* Dependency: golang.org/x/text
 
 #### LICENSE
 
@@ -3239,7 +3239,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ### golang.org/x/time/rate
 
 * License: BSD-3-Clause
-* Module: golang.org/x/time@v0.14.0
+* Dependency: golang.org/x/time
 
 #### LICENSE
 
@@ -3278,7 +3278,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ### google.golang.org/protobuf
 
 * License: BSD-3-Clause
-* Module: google.golang.org/protobuf@v1.36.12-0.20260120151049-f2248ac996af
+* Dependency: google.golang.org/protobuf
 
 #### LICENSE
 
@@ -3317,7 +3317,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ### gopkg.in/evanphx/json-patch.v4
 
 * License: BSD-3-Clause
-* Module: gopkg.in/evanphx/json-patch.v4@v4.13.0
+* Dependency: gopkg.in/evanphx/json-patch.v4
 
 #### LICENSE
 
@@ -3354,7 +3354,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ### gopkg.in/inf.v0
 
 * License: BSD-3-Clause
-* Module: gopkg.in/inf.v0@v0.9.1
+* Dependency: gopkg.in/inf.v0
 
 #### LICENSE
 
@@ -3394,7 +3394,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ### gopkg.in/yaml.v2
 
 * License: Apache-2.0
-* Module: gopkg.in/yaml.v2@v2.4.0
+* Dependency: gopkg.in/yaml.v2
 
 #### LICENSE
 
@@ -3626,7 +3626,7 @@ limitations under the License.
 ### gopkg.in/yaml.v3
 
 * License: MIT
-* Module: gopkg.in/yaml.v3@v3.0.1
+* Dependency: gopkg.in/yaml.v3
 
 #### LICENSE
 
@@ -3707,7 +3707,7 @@ limitations under the License.
 ### k8s.io/api
 
 * License: Apache-2.0
-* Module: k8s.io/api@v0.36.3
+* Dependency: k8s.io/api
 
 #### LICENSE
 
@@ -3921,7 +3921,7 @@ limitations under the License.
 ### k8s.io/apimachinery/pkg
 
 * License: Apache-2.0
-* Module: k8s.io/apimachinery@v0.36.3
+* Dependency: k8s.io/apimachinery
 
 #### LICENSE
 
@@ -4135,7 +4135,7 @@ limitations under the License.
 ### k8s.io/apimachinery/third_party/forked/golang
 
 * License: BSD-3-Clause
-* Module: k8s.io/apimachinery@v0.36.3
+* Dependency: k8s.io/apimachinery
 
 #### LICENSE
 
@@ -4174,7 +4174,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ### k8s.io/client-go
 
 * License: Apache-2.0
-* Module: k8s.io/client-go@v0.36.3
+* Dependency: k8s.io/client-go
 
 #### LICENSE
 
@@ -4388,7 +4388,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ### k8s.io/klog/v2
 
 * License: Apache-2.0
-* Module: k8s.io/klog/v2@v2.140.0
+* Dependency: k8s.io/klog/v2
 
 #### LICENSE
 
@@ -4591,7 +4591,7 @@ third-party archives.
 ### k8s.io/kube-openapi/pkg
 
 * License: Apache-2.0
-* Module: k8s.io/kube-openapi@v0.0.0-20260317180543-43fb72c5454a
+* Dependency: k8s.io/kube-openapi
 
 #### LICENSE
 
@@ -4805,7 +4805,7 @@ third-party archives.
 ### k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json
 
 * License: BSD-3-Clause
-* Module: k8s.io/kube-openapi@v0.0.0-20260317180543-43fb72c5454a
+* Dependency: k8s.io/kube-openapi
 
 #### LICENSE
 
@@ -4844,7 +4844,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ### k8s.io/kube-openapi/pkg/validation/spec
 
 * License: Apache-2.0
-* Module: k8s.io/kube-openapi@v0.0.0-20260317180543-43fb72c5454a
+* Dependency: k8s.io/kube-openapi
 
 #### LICENSE
 
@@ -5058,7 +5058,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ### k8s.io/utils
 
 * License: Apache-2.0
-* Module: k8s.io/utils@v0.0.0-20260210185600-b8788abfbbc2
+* Dependency: k8s.io/utils
 
 #### LICENSE
 
@@ -5272,7 +5272,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ### k8s.io/utils/internal/third_party/forked/golang/net
 
 * License: BSD-3-Clause
-* Module: k8s.io/utils@v0.0.0-20260210185600-b8788abfbbc2
+* Dependency: k8s.io/utils
 
 #### LICENSE
 
@@ -5311,7 +5311,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ### sigs.k8s.io/json
 
 * License: Apache-2.0 / BSD-3-Clause
-* Module: sigs.k8s.io/json@v0.0.0-20250730193827-2d320260d730
+* Dependency: sigs.k8s.io/json
 
 #### LICENSE
 
@@ -5561,7 +5561,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ### sigs.k8s.io/randfill
 
 * License: Apache-2.0
-* Module: sigs.k8s.io/randfill@v1.0.0
+* Dependency: sigs.k8s.io/randfill
 
 #### LICENSE
 
@@ -5805,7 +5805,7 @@ Submitted on behalf of a third-party: @disconnect3d (Disconnect3d)
 ### sigs.k8s.io/structured-merge-diff/v6
 
 * License: Apache-2.0
-* Module: sigs.k8s.io/structured-merge-diff/v6@v6.3.3
+* Dependency: sigs.k8s.io/structured-merge-diff/v6
 
 #### LICENSE
 
@@ -6018,7 +6018,7 @@ Submitted on behalf of a third-party: @disconnect3d (Disconnect3d)
 ### sigs.k8s.io/yaml
 
 * License: Apache-2.0 / BSD-3-Clause / MIT
-* Module: sigs.k8s.io/yaml@v1.6.0
+* Dependency: sigs.k8s.io/yaml
 
 #### LICENSE
 

--- a/hack/generate-third-party-notices.sh
+++ b/hack/generate-third-party-notices.sh
@@ -237,7 +237,7 @@ collapse_index() {
 }
 
 # In vendor mode go-licenses reports a URL into this repo at HEAD, which stops
-# describing released content once main moves; module@version is immutable.
+# describing released content once main moves; module path is immutable.
 annotate_modules() {
     awk -v modfile="${MODULES_TXT}" '
         BEGIN {
@@ -255,10 +255,10 @@ annotate_modules() {
                         exit 1
                     }
                     mods[++m] = f[2]
-                    disp[f[2]] = f[r] "@" f[r + 1]
+                    disp[f[2]] = f[r]
                 } else {
                     mods[++m] = f[2]
-                    disp[f[2]] = f[2] "@" f[3]
+                    disp[f[2]] = f[2]
                 }
             }
             close(modfile)
@@ -300,7 +300,7 @@ build_indexes() {
     done
 
     if cut -d, -f4 "${INDEX_FILE}" | LC_ALL=C grep -qx 'unknown'; then
-        die "could not resolve module@version for some runtime packages from ${MODULES_TXT}." \
+        die "could not resolve a module for some runtime packages from ${MODULES_TXT}." \
             "Run 'make vendor' and re-run, rather than committing a file with unattributed entries."
     fi
 
@@ -329,7 +329,7 @@ license_files_for() {
 emit_index_table() {
     local index="$1" provenance="$2" pkg url license module
     if [[ "${provenance}" == "module" ]]; then
-        printf '| Package | License | Module |\n'
+        printf '| Package | License | Dependency |\n'
     else
         printf '| Package | License | Source |\n'
     fi
@@ -356,7 +356,7 @@ emit_sections() {
         printf '### %s\n\n' "${pkg}"
         printf '* License: %s\n' "${license:-Unknown}"
         if [[ "${provenance}" == "module" ]]; then
-            printf '* Module: %s\n\n' "${module:-unknown}"
+            printf '* Dependency: %s\n\n' "${module:-unknown}"
         else
             printf '* Source: %s\n\n' "${url:-n/a}"
         fi


### PR DESCRIPTION
This change edits the generate-third-party-notices.sh script to omit go-module verisons from the rendered TPN doc. It also regenerates the TPN doc.