### PR TITLE
[ci] ignore cooldown for nvidia controlled repos

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
+    cooldown:
+      exclude:
+      - github.com/NVIDIA/*
     labels:
     - dependencies
     groups:
@@ -34,6 +37,9 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
+    cooldown:
+      exclude:
+      - github.com/NVIDIA/*
 
   - package-ecosystem: "docker"
     target-branch: main


### PR DESCRIPTION
This PR updates dependabot to ignore cooldown for nvidia controlled repos.