### PR TITLE
Bump golang version to 1.26.6

### DIFF
--- a/deployments/devel/Dockerfile
+++ b/deployments/devel/Dockerfile
@@ -14,7 +14,7 @@
 
 # This Dockerfile is also used to define the golang version used in this project
 # This allows dependabot to manage this version in addition to other images.
-FROM golang:1.26.5
+FROM golang:1.26.6
 
 WORKDIR /work
 COPY * .


### PR DESCRIPTION
Manual bump: dependabot considers the `1.27rc2` docker tag the latest golang version, so it does not propose stable patch updates.