### PR TITLE
Manage the Go toolchain version with Renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,9 +40,3 @@ updates:
     cooldown:
       exclude:
       - github.com/NVIDIA/*
-
-  - package-ecosystem: "docker"
-    target-branch: main
-    directory: "/deployments/devel"
-    schedule:
-      interval: "daily"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":disableDependencyDashboard"
+  ],
+  "forkProcessing": "enabled",
+  "ignorePaths": ["vendor/**"],
+  "enabledManagers": ["custom.regex"],
+  "recreateWhen": "always",
+  "pruneStaleBranches": true,
+  "rebaseWhen": "always",
+
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "deployments/devel/Dockerfile"
+      ],
+      "matchStrings": [
+        "FROM golang:(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
+      "depNameTemplate": "go",
+      "datasourceTemplate": "golang-version",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "deployments/container/Dockerfile"
+      ],
+      "matchStrings": [
+        "ARG GOLANG_VERSION=(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
+      "depNameTemplate": "go",
+      "datasourceTemplate": "golang-version",
+      "versioningTemplate": "semver"
+    }
+  ],
+  "labels": [
+    "dependencies",
+    "renovate"
+  ],
+  "packageRules": [
+    {
+      "description": "Group all Go toolchain version bumps into a single PR",
+      "matchManagers": ["custom.regex"],
+      "matchPackageNames": ["go"],
+      "matchDatasources": ["golang-version"],
+      "groupName": "Go toolchain",
+      "groupSlug": "go-toolchain",
+      "separateMajorMinor": false,
+      "separateMinorPatch": false
+    }
+  ]
+}

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Run Renovate
-        uses: renovatebot/github-action@v46.1.21
+        uses: renovatebot/github-action@v46.2.2
         with:
           configurationFile: .github/renovate.json
         env:

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,22 @@
+name: Renovate
+
+on:
+  workflow_dispatch:
+  schedule:
+     - cron: "0 9 * * *" # every day at 9:00 AM UTC
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Run Renovate
+        uses: renovatebot/github-action@v46.1.21
+        with:
+          configurationFile: .github/renovate.json
+        env:
+          RENOVATE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RENOVATE_REPOSITORIES: '["NVIDIA/mig-parted"]'
+          RENOVATE_ONBOARDING: false

--- a/deployments/container/Dockerfile
+++ b/deployments/container/Dockerfile
@@ -21,7 +21,7 @@ RUN yum install -y \
      && \
     rm -rf /var/cache/yum/*
 
-ARG GOLANG_VERSION=1.22.8
+ARG GOLANG_VERSION=1.26.6
 RUN set -eux; \
     \
     arch="$(uname -m)"; \


### PR DESCRIPTION
Dependabot's docker manager treats Go's RC docker tags (e.g. `1.27rc2`) as the latest version and stops proposing stable patch updates once the RC update is declined.

Run a self-hosted Renovate daily with regex managers backed by the `golang-version` datasource, which only serves stable Go releases. One grouped PR updates both the golang bootstrap image in the devel Dockerfile and the `GOLANG_VERSION` build-arg default in the container Dockerfile; the latter was stale at 1.22.8 because real builds always override it. Drop the dependabot docker entry for `deployments/devel` so the two bots do not race on the same line.

Renovate manages Go version in GPU Operator, so this matches it. 