### PR TITLE
Bump version to v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # NVIDIA MIG Manager Changelog
 
+## v0.15.0
+- Use the GI profile ID from the target device when reporting the current MIG config
+- Add support for bouncing third-party GPU client pods during a MIG config apply
+- Support optional subsystem ID matching in device filters
+- Ship a static busybox shell in the mig-parted image
+- Surface service.sh failures in the nvidia-mig-manager unit status
+- Migrate to urfave/cli/v3
+- Bump NVIDIA Container Toolkit version to v1.20.0
+- Bump distroless base image version to v4.1.1
+- Bump CUDA base image version to 13.3.1-base-ubi8
+- Bump github.com/NVIDIA/go-nvlib to v0.12.0
+- Bump github.com/NVIDIA/go-nvml to v0.13.3-1
+- Bump k8s golang dependencies to v0.36.3
+- Bump golang version to 1.26.6
+
 ## v0.14.5
 - Skip container runtime calls in hooks to avoid deadlocks
 - Add a start timeout of 480 seconds to nvidia-mig-manager.service

--- a/deployments/container/nvidia-mig-manager-example-hopper-blackwell.yaml
+++ b/deployments/container/nvidia-mig-manager-example-hopper-blackwell.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: nvidia-mig-manager-service-account
       containers:
       - name: nvidia-mig-manager
-        image: nvcr.io/nvidia/cloud-native/k8s-mig-manager:v0.14.5
+        image: nvcr.io/nvidia/cloud-native/k8s-mig-manager:v0.15.0
         imagePullPolicy: IfNotPresent
         env:
         - name: NODE_NAME

--- a/deployments/container/nvidia-mig-manager-example.yaml
+++ b/deployments/container/nvidia-mig-manager-example.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: nvidia-mig-manager-service-account
       containers:
       - name: nvidia-mig-manager
-        image: nvcr.io/nvidia/cloud-native/k8s-mig-manager:v0.14.5
+        image: nvcr.io/nvidia/cloud-native/k8s-mig-manager:v0.15.0
         imagePullPolicy: IfNotPresent
         env:
         - name: NODE_NAME

--- a/versions.mk
+++ b/versions.mk
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 MODULE := github.com/NVIDIA/mig-parted
-VERSION ?= v0.14.5
+VERSION ?= v0.15.0
 
 GOLANG_VERSION := $(shell ./hack/golang-version.sh)
 


### PR DESCRIPTION
In preparation for v0.15.0 release.

This minor release primarily contains these changes on top of v0.14.5:
- https://github.com/NVIDIA/mig-parted/pull/372
- https://github.com/NVIDIA/mig-parted/pull/426
- https://github.com/NVIDIA/mig-parted/pull/435
- https://github.com/NVIDIA/mig-parted/pull/385
- https://github.com/NVIDIA/mig-parted/pull/360
- https://github.com/NVIDIA/mig-parted/pull/265