### PR TITLE
Set failed state when pod-deletion wait or validator restart fails

### DIFF
--- a/pkg/mig/reconfigure/reconfigure.go
+++ b/pkg/mig/reconfigure/reconfigure.go
@@ -168,6 +168,7 @@ func (r *Reconfigure) Run() error {
 	}
 
 	if err := r.waitForPodsToBeDeleted(); err != nil {
+		_ = r.setState(migStateFailed)
 		return fmt.Errorf("failed to wait for pods to be deleted: %w", err)
 	}
 
@@ -228,6 +229,7 @@ func (r *Reconfigure) Run() error {
 	}
 
 	if err := r.restartValidatorPod(); err != nil {
+		_ = r.setState(migStateFailed)
 		return fmt.Errorf("failed to restart validator pod: %w", err)
 	}
 


### PR DESCRIPTION
These were the only two failure paths in `Run()` that skipped `setState(migStateFailed)`, leaving `gpu.deploy.*` labels at `paused-for-mig-change` and `mig.config.state` at `pending` with no retry trigger — all GPU clients stayed disabled until the `mig.config` label changed or the pod was restarted. Calling setState restores the labels and sets the state to `failed` so the condition is detectable, matching every other failure path.

Fixes NVIDIA/mig-parted#485